### PR TITLE
chore: Add basic repo configurations

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+tab_width = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.go]
+indent_style = tab
+
+[Makefile]
+indent_style = tab
+
+[{*.yaml,*.yml}]
+indent_size = 2
+tab_width = 2
+
+[*.md]
+max_line_length = off
+# Trailing whitespaces are needed in markdown for line breaks
+trim_trailing_whitespace = false

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# This file is used to assign reviewers to PRs based on ownerships
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Per default maintainer review is requested
+* @Dynatrace/monaco-maintainers

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Report a bug you already know details about
+about: Report a detailed bug - if in doubt please contact Support first
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Describe the usage of the library**
+How did you use the library for this bug to occur? In a specific existing Dynatrace too?
+
+**How to reproduce**
+Steps to reproduce the behavior.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Log output**
+If applicable, add log snippets to help explain your problem.
+
+**Environment (please complete the following information):**
+ - OS: [e.g. Win 10, Ubuntu Linux, macOs Catalina]
+ - Library version [e.g. 1.0.1]
+ - How was the library used/in which config-as-code tool did the library issue occur?
+ - Specific Module?
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Suggest changes you'd like to contribute
+    url: https://github.com/Dynatrace/dynatrace-configuration-as-code-core/discussions/new?category=ideas
+    about: Before you open a PR, we'd love to get a chance to discuss your proposed changes.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+<!--  Thanks for sending a pull request! 
+If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code-core/blob/main/CONTRIBUTING.md
+
+Before submitting this PR, please make sure that:
+1. Your code builds without any errors or warnings
+2. Your code is covered by unit tests
+3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
+-->
+
+#### What this PR does / Why we need it:
+
+#### Special notes for your reviewer:
+
+#### Does this PR introduce a user-facing change?
+<!--
+If no, just write "NONE" or leave this section empty.
+If yes, state how the user is impacted by your changes.
+-->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "Dynatrace/monaco-maintainers"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "Dynatrace/monaco-maintainers"
+    commit-message:
+      prefix: "chore"
+      include: "scope"

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,62 @@
+name: Build and Test
+
+# This workflow builds the code and runs the unit tests and integration tests.
+#
+# If this workflow is executed in the context of a fork, the integration tests are
+# skipped and just the unit tests are executed. See the workflow "Trigger
+# Integration Tests for Forks" for more details on how the integration tests are
+# executed for forks.
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  schedule:
+    # this is checking periodically if there are any breaking API changes
+    # Every day at 00:00
+    - cron: '0 0 * * *'
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build_test:
+    name: Build and Test
+    permissions:
+      contents: read
+      checks: write
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 🛠️ Set up Go 1.x
+        uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 #v4.0.1
+        with:
+          go-version: '~1.20'
+
+      - name: ⬇️ Check out code into the Go module directory
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
+
+      - name: 🏗️ Compile
+        run: make compile
+
+      - name: 🧪 Unit test
+        run: make test testopts="--junitfile test-result-${{ matrix.os }}-unit.xml"
+
+      - name: ⬆️ Upload Test Results
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce #v3.1.2
+        if: always()
+        with:
+          name: Test Results
+          path: test-result-*.xml
+
+  upload_event:
+    name: "Upload Event File"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Upload
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce #v3.1.2
+        with:
+          name: event_file
+          path: ${{ github.event_path }}

--- a/.github/workflows/collect-test-results.yml
+++ b/.github/workflows/collect-test-results.yml
@@ -1,0 +1,51 @@
+name: Test Results
+
+# This workflow runs after the CI 'Build and Test' workflow has completed,
+# to collect test results in JUnit format and post a comment on test test status to a PR.
+# This split setup is required to correctly work on forks and dependabot PRs, as described here:
+# https://github.com/EnricoMi/publish-unit-test-result-action/blob/v1.20/README.md#support-fork-repositories-and-dependabot-branches
+
+on:
+  workflow_run:
+    workflows: [ "Build and Test" ]
+    types:
+      - completed
+
+env:
+  ARTIFACT_PATH: "artifacts"
+
+jobs:
+  unit-test-results:
+    name: Unit Test Results
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      issues: read
+      checks: write
+      pull-requests: write
+    if: github.event.workflow_run.conclusion != 'skipped'
+
+    steps:
+      - name: Get Artifacts of Build Action
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: |
+          mkdir -p ${{ env.ARTIFACT_PATH }} && cd ${{ env.ARTIFACT_PATH }}
+
+          artifacts_url=${{ github.event.workflow_run.artifacts_url }}
+
+          gh api "$artifacts_url" -q '.artifacts[] | [.name, .archive_download_url] | @tsv' | while read artifact
+          do
+            IFS=$'\t' read name url <<< "$artifact"
+            gh api $url > "$name.zip"
+            unzip -d "$name" "$name.zip"
+          done
+
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action@283dea176069279a9076e77b548668a8e4f0c31b #v2.9.0
+        with:
+          commit: ${{ github.event.workflow_run.head_sha }}
+          event_file: ${{ env.ARTIFACT_PATH }}/event_file/event.json
+          event_name: ${{ github.event.workflow_run.event }}
+          files: ${{ env.ARTIFACT_PATH }}/**/*.xml

--- a/.github/workflows/conventional_commit.yml
+++ b/.github/workflows/conventional_commit.yml
@@ -1,0 +1,19 @@
+name: Commit Compliance
+
+# This workflow runs on pull requests
+# to make sure your commits are compliant with conventional commits.
+# https://www.conventionalcommits.org/en/v1.0.0/
+
+on: [ pull_request ]
+jobs:
+  validate-commits:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+    steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
+        with:
+          fetch-depth: 0
+      - name: Commitsar check
+        uses: aevea/commitsar@916c7b483225a30d3a17f407fa25f5b25888ea69 #v0.20.2

--- a/.github/workflows/dependencies-and-licenses.yml
+++ b/.github/workflows/dependencies-and-licenses.yml
@@ -1,0 +1,39 @@
+name: Dependencies and Licenses
+on:
+  release:
+    types:
+      - published
+defaults:
+  run:
+    shell: bash
+jobs:
+  generate-dependencies:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout Core Repo
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
+      - name: Set up Go
+        uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 #v4.0.1
+        with:
+          go-version: '~1.20'
+      - name: Install go-licence-detector
+        run: |
+          go install go.elastic.co/go-licence-detector@v0.6.0
+      - name: Clean Go mod
+        run: go mod tidy
+      - name: Generate SBOM in CycloneDX format
+        uses: CycloneDX/gh-gomod-generate-sbom@efc74245d6802c8cefd925620515442756c70d8f #v2.0.0
+        with:
+            version: v1
+            args: mod -licenses -output sbom.xml
+      - name: Upload SBOM artifact
+        run: |
+            curl --request POST "https://uploads.github.com/repos/Dynatrace/dynatrace-configuration-as-code-core/releases/${{ github.event.release.id }}/assets?name=sbom.xml" \
+                 --header "Accept: application/vnd.github+json" \
+                 --header "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+                 --header "X-GitHub-Api-Version: 2022-11-28" \
+                 --header "Content-Type: application/octet-stream" \
+                 --fail \
+                 --data-binary @sbom.xml

--- a/.github/workflows/pr-static-code-analysis.yml
+++ b/.github/workflows/pr-static-code-analysis.yml
@@ -1,0 +1,38 @@
+name: Run Static Code Analysis
+
+# This workflow uses golangci-lint to run static code analysis on PRs
+# In addition to default golanci-linters checks vulnerability checks (gosec),
+# closing of openend http bodies (bodyclose), cyclomatic complexity (cyclop),
+# exhaustive switches (exhaustive) and open TODO/FIXME comments (godox)
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  verify:
+    name: Verify
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+    steps:
+      - name: 🛠️ Set up Go 1.x
+        uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 #v4.0.1
+        with:
+          go-version: '~1.20'
+
+      - name: ⬇️ Check out code into the Go module directory
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
+
+      - name: ✍️ Check format
+        run: make lint
+
+      - name: 🕵️ Go vet
+        run: make vet
+
+      - name: 🔎 golangci-lint
+        uses: reviewdog/action-golangci-lint@22adb9d08853436506154413f5683c2e749d3b85 #v2.3.3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-check

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,33 @@
+name: Semgrep Security Scan
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+  schedule:
+    - cron: '0 1 * * *'
+
+jobs:
+  semgrep:
+    name: Scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+
+    container:
+      # A Docker image with Semgrep installed. Do not change this.
+      image: returntocorp/semgrep@sha256:edeb16c525187998ebcd2f88e6c0e6819c71b87b871665d15fef1eb8893f5ddc #v1.23.0
+
+    # Skip any PR created by dependabot to avoid permission issues:
+    if: (github.actor != 'dependabot[bot]')
+
+    steps:
+      # Fetch project source with GitHub Actions Checkout.
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
+      # Run the "semgrep ci" command on the command line of the docker image.
+      - run: semgrep ci
+        env:
+          # Add the rules that Semgrep uses by setting the SEMGREP_RULES environment variable - more at semgrep.dev/explore.
+          SEMGREP_RULES: p/default p/golang p/github-actions p/docker

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# IDEs
+.idea/*
+.vscode/
+*.iml
+.run/
+!.idea/copyright
+
+# Mock files
+**/*_mock.go
+
+# Generated files
+sbom.xml
+
+# Misc
+.DS_Store
+*.env
+config.json

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,24 @@
+linters:
+  enable:
+    - gocognit
+    - godox
+    - dupl
+    - tenv
+    - noctx
+  presets:
+    - bugs
+    - unused
+  disable:
+    - varcheck # deprecated
+    - deadcode # deprecated
+    - scopelint # deprecated
+    - structcheck # deprecated
+
+linters-settings:
+  gocognit:
+    min-complexity: 25
+  dupl:
+    threshold: 75
+run:
+  skip-files:
+    - '.*_test\.go$'

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor covenant code of conduct
+
+## Our pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+ advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+ address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+ professional setting
+
+## Our responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This code of conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project email
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at opensource@dynatrace.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce this code of conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This code of conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,121 @@
+# Contributing to the Dynatrace Configuration as Code Core Libraries
+
+- [Contributing to the Dynatrace Configuration as Code Core Libraries](#contributing-to-the-dynatrace-configuration-as-code-core-libraries)
+  - [What to contribute](#what-to-contribute)
+  - [How to contribute](#how-to-contribute)
+    - [Examples of Commit Style Messages](#examples-of-commit-style-messages)
+  - [Code of Conduct and Shared Values](#code-of-conduct-and-shared-values)
+  - [Building the Dynatrace Configuration as Code Core libraries](#building-the-dynatrace-configuration-as-code-core-libraries)
+  - [Testing the Dynatrace Configuration as Code Core libraries](#testing-the-dynatrace-configuration-as-code-core-libraries)
+    - [Writing Tests](#writing-tests)
+  - [Checking in go mod and sum files](#checking-in-go-mod-and-sum-files)
+  - [General information on code](#general-information-on-code)
+    - [Test Mocks](#test-mocks)
+    - [Formatting](#formatting)
+  - [Pre-Commit Hook](#pre-commit-hook)
+
+
+## What to contribute
+
+Dynatrace Configuration as Code Core provides libraries simplifying the development of configuration as code tooling for Dynatrace.
+
+It provides Go libraries for things like API clients, which are shared between several Dynatrace configuration as code tools.
+
+## How to contribute
+
+The easiest way to start contributing or helping with the Configuration as Code Core project is to pick an existing [issue/bug](https://github.com/dynatrace/dynatrace-configuration-as-code-core/issues) and [get to work](#building-the-dynatrace-configuration-as-code-core-libraries).
+
+For proposing a change, we seek to discuss potential changes in GitHub issues in advance before implementation. 
+That will allow us to give design feedback up front and set expectations about the scope of the change and, for more significant changes, 
+how best to approach the work such that the Configuration as Code team can review it and merge it with other concurrent work. 
+This allows being respectful of the time of community contributors.
+
+The repo follows a relatively standard branching & PR workflow.
+
+Branches naming follows the `feature/{Issue}/{description}` or `bugfix/{Issue}/{description}` pattern.
+
+Branches are rebased, and only fast-forward merges to main are permitted. No merge commits.
+
+By default, commits are not auto-squashed when merging a PR, so please ensure your commits are fit to go into main.
+
+For convenience auto-squashing all PR commits into a single one is an optional merge strategy - but we strive for [atomic commits](https://www.freshconsulting.com/insights/blog/atomic-commits/)
+with [good commit messages](https://cbea.ms/git-commit/) in main so not auto-squashing is recommended.
+
+Commits should conform to  [Conventional Commit](https://www.conventionalcommits.org/) standard.
+
+### Examples of Commit Style Messages
+
+New Feature Changes
+``` 
+feat: allow provided config object to extend other configs
+```
+
+Bug Fix Changes
+```
+fix: change function call
+
+see the issue for details
+
+on typos fixed.
+
+Reviewed-by: Z
+Refs #133 
+```
+
+Documentation Changes
+```
+docs: correct getting started guide 
+```
+
+More examples can be found [here](https://www.conventionalcommits.org/en/v1.0.0/#examples)
+
+
+## Code of Conduct and Shared Values
+
+Before contributing, please read and approve [our Code Of Conduct](https://github.com/dynatrace/dynatrace-configuration-as-code-core/blob/main/CODE_OF_CONDUCT.md) outlining our shared values and expectations. 
+
+## Building the Dynatrace Configuration as Code Core libraries
+
+The libraries are written in [Go](https://golang.org/), so you will need to have [installed Go](https://golang.org/dl/) to build it.
+
+As the libraries themselves provide no exectuable you may compile them using `make compile`, but there are no executables to be built and used.
+
+Generally make sure to take a look at the [Makefile](./Makefile) to see available build targets.
+
+## Testing the Dynatrace Configuration as Code Core libraries
+
+Run the unit tests for the whole module with `make test` in the root folder.
+
+### Writing Tests
+
+Take a look at [Go Testing](https://golang.org/pkg/testing/) for more info on testing in Go.
+
+We use [github.com/stretchr/testify](github.com/stretchr/testify) as a testing/assert library.
+
+In general, we aim for test coverage above 80% but do not enfore hard limits, please make sure your code is reasonably well covered by tests.
+
+## Checking in go mod and sum files
+
+Go module files `go.mod` and `go.sum` are checked-in in the root folder of the repo, so generally run `go` from there.
+
+`mod` and `sum` may change while building the project.
+To keep those files clean off unnecessary changes, please always run `go mod tidy` before committing changes to these files!
+
+## General information on code
+
+### Test Mocks
+
+Go Mockgen is used for some generated mock files.
+You will have to generate them.
+To explicitly generate the mocked files, run `make mocks` in the root folder.
+
+### Formatting
+
+This project uses the default go formatting tool `go fmt`.
+
+To format all files, you can use the Make target `make format`.
+
+## Pre-Commit Hook
+
+Before committing changes, please make sure you've added the `pre-commit` hook from the hooks folder.
+On Unix, you can use the `setup-git-hooks.sh` to symlink that file into your `.git/hooks` folder.

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2023 Dynatrace LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,53 @@
+.PHONY: default setup lint format add-license-headers vet check compile test update-dependencies
+
+default: test
+
+setup:
+	@echo "Installing build tools..."
+	@go install github.com/google/addlicense@v1.1.1
+	@go install gotest.tools/gotestsum@v1.10.1
+
+lint: setup
+ifeq ($(OS),Windows_NT)
+	@.\tools\check-format.cmd
+else
+	@go install github.com/google/addlicense@v1
+	@sh ./tools/check-format.sh
+	@sh ./tools/check-license-headers.sh
+	@go mod tidy
+endif
+
+format:
+	@gofmt -w .
+
+add-license-headers:
+ifeq ($(OS),Windows_NT)
+	@echo "This is currently not supported on windows"
+	@exit 1
+else
+	@sh ./tools/add-missing-license-headers.sh
+endif
+
+vet:
+	@echo "Vetting files"
+	@go vet -tags '!unit' ./...
+
+check:
+	@echo "Static code analysis"
+	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1
+	@golangci-lint run ./...
+
+compile:
+	@echo "Compiling sources..."
+	@go build ./...
+	@echo "Compiling tests..."
+	@go test -run "NON_EXISTENT_TEST_TO_ENSURE_NOTHING_RUNS_BUT_ALL_COMPILE" ./...
+
+test: setup
+	@echo "Testing $(BINARY_NAME)..."
+	@gotestsum ${testopts} -- -v -race ./...
+
+update-dependencies:
+	@echo Update go dependencies
+	@go get -u ./...
+	@go mod tidy

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-# dynatrace-configuration-as-code-core
+# Dynatrace Configuration as Code - Core
+
+Dynatrace Configuration as Code Core provides libraries simplifying development of configuration as code tooling for Dynatrace.
+
+It provides Go libraries for things like API clients, which are shared between several Dynatrace configuration as code tools.
+
+## Forms of Dynatrace Configuration as Code
+
+* [Dynatrace Configuration as Code CLI Monaco](https://github.com/dynatrace/dynatrace-configuration-as-code)
+* [Dynatrace Terraform provider](https://github.com/dynatrace-oss/terraform-provider-dynatrace).

--- a/tools/add-missing-license-headers.sh
+++ b/tools/add-missing-license-headers.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# NOTE: This is meant to be run inside the repo root as ./tools/add-license-headers.sh
+
+addlicense -f tools/license_header.txt $(find . -type f -name '*.go' -not -path '*_mock.go')

--- a/tools/check-format.cmd
+++ b/tools/check-format.cmd
@@ -1,0 +1,17 @@
+@ECHO off
+REM  NOTE: This is meant to be run inside the repo root as ./tools/check-format.sh
+
+echo Checking files for correct go formatting...
+
+for /f %%i in ('gofmt -l .') do set WRONG_FORMAT=%%i
+
+REM if gofmt found no files with wrong formatting, exit ok
+if not defined WRONG_FORMAT (
+    exit 0
+) else (
+    REM else print and fail
+    echo Unformatted files found!
+    echo %WRONG_FORMAT%
+    echo Please format them using gofmt!
+    exit 1
+)

--- a/tools/check-format.sh
+++ b/tools/check-format.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# NOTE: This is meant to be run inside the repo root as ./tools/check-format.sh
+
+echo "Checking files for correct go formatting..."
+
+WRONG_FORMAT=$(gofmt -l .)
+
+# if gofmt found no files with wrong formatting, exit ok
+[ -z "$WRONG_FORMAT" ] && exit 0
+
+# else print and fail
+echo >&2 "Unformatted files found!\n\n$WRONG_FORMAT\n\nPlease format them using gofmt!"
+exit 1

--- a/tools/check-license-headers.sh
+++ b/tools/check-license-headers.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# NOTE: This is meant to be run inside the repo root as ./tools/check-license-headers.sh
+
+echo "Checking files for license header..."
+
+WRONG_FORMAT=$(addlicense -f tools/license_header.txt --check $(git ls-files --exclude '*_mock.go' '*.go') | sort)
+
+# if gofmt found no files with wrong formatting, exit ok
+[ -z "$WRONG_FORMAT" ] && exit 0
+
+# else print and fail
+printf >&2 "Files with missing license header found found!\n\n${WRONG_FORMAT}\n\nPlease add license header!"
+exit 1

--- a/tools/format-commit-changes.sh
+++ b/tools/format-commit-changes.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+FILES=$(git diff --name-only --cached | grep .go)
+[ -z "$FILES" ] && exit 0
+
+echo "Running go formatter on commit..."
+
+WRONG_FORMAT=$(go fmt ${FILES})
+
+# if gofmt found no files with wrong formatting, exit ok
+[ -z "$WRONG_FORMAT" ] && exit 0
+
+# else print and fail
+echo >&2 "Wrongly formatted files found and corrected!\n\n$WRONG_FORMAT\n\nPlease change files added to your commit now!"
+exit 1

--- a/tools/license_header.txt
+++ b/tools/license_header.txt
@@ -1,0 +1,13 @@
+@license
+Copyright {{.Year}} Dynatrace LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/tools/setup-git-hooks.sh
+++ b/tools/setup-git-hooks.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# NOTE: This is meant to be run inside the repo root as ./tools/setup-git-hooks.sh
+
+dir=$(pwd)
+ln -sf $dir/tools/format-commit-changes.sh $dir/.git/hooks/pre-commit


### PR DESCRIPTION
Add basic versions of readme, license, code-of-conduct, contributing files, as well as a basic build and CI/CD setup based on the existing ones from the monaco CLI.