### PR TITLE
chore: Update codeowners to shared maintainer group

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # Per default maintainer review is requested
-* @Dynatrace/monaco-maintainers
+* @Dynatrace/config-as-code-core-maintainers


### PR DESCRIPTION
Previously this was set to the maintainer group for monaco, but a new shared group of config-as-code tooling maintainers exists and is better suiter as reviewers for this repo.

