### PR TITLE
feat: add possibility to convert an Response into an APIError

### DIFF
--- a/api/clients/buckets/bucket.go
+++ b/api/clients/buckets/bucket.go
@@ -92,7 +92,7 @@ func (c Client) Get(ctx context.Context, bucketName string) (Response, error) {
 	if err != nil {
 		return Response{}, err
 	}
-	return Response{api.Response{StatusCode: resp.StatusCode, Data: resp.Payload}}, nil
+	return Response{api.Response{StatusCode: resp.StatusCode, Data: resp.Payload, Request: resp.RequestInfo}}, nil
 }
 
 // List retrieves all bucket definitions. The function sends a GET request
@@ -154,6 +154,7 @@ func (c Client) Create(ctx context.Context, bucketName string, data []byte) (Res
 		Response: api.Response{
 			StatusCode: resp.StatusCode,
 			Data:       resp.Payload,
+			Request:    resp.RequestInfo,
 		},
 	}, nil
 }
@@ -199,12 +200,13 @@ func (c Client) Update(ctx context.Context, bucketName string, data []byte) (Res
 			return Response{api.Response{
 				StatusCode: resp.StatusCode,
 				Data:       resp.Payload,
+				Request:    resp.RequestInfo,
 			}}, nil
 		}
 
 		if resp.IsSuccess() {
 			logger.Info(fmt.Sprintf("Updated bucket with bucket name %q", bucketName))
-			return Response{api.Response{StatusCode: resp.StatusCode, Data: resp.Payload}}, nil
+			return Response{api.Response{StatusCode: resp.StatusCode, Data: resp.Payload, Request: resp.RequestInfo}}, nil
 		}
 		time.Sleep(waitDuration)
 	}
@@ -212,6 +214,7 @@ func (c Client) Update(ctx context.Context, bucketName string, data []byte) (Res
 		Response: api.Response{
 			StatusCode: resp.StatusCode,
 			Data:       resp.Payload,
+			Request:    resp.RequestInfo,
 		},
 	}, err
 }
@@ -269,7 +272,7 @@ func (c Client) Delete(ctx context.Context, bucketName string) (Response, error)
 	if err != nil {
 		return Response{}, fmt.Errorf("unable to delete object with bucket name %q: %w", bucketName, err)
 	}
-	return Response{api.Response{StatusCode: resp.StatusCode, Data: resp.Payload}}, err
+	return Response{api.Response{StatusCode: resp.StatusCode, Data: resp.Payload, Request: resp.RequestInfo}}, err
 }
 
 // upsert is an internal function used by Upsert to perform the create or update logic.
@@ -286,7 +289,7 @@ func (c Client) upsert(ctx context.Context, bucketName string, data []byte) (Res
 	// If creating the bucket definition worked, return the result
 	if resp.IsSuccess() {
 		logger.Info(fmt.Sprintf("Created bucket with bucket name %q", bucketName))
-		return Response{api.Response{StatusCode: resp.StatusCode, Data: resp.Payload}}, nil
+		return Response{api.Response{StatusCode: resp.StatusCode, Data: resp.Payload, Request: resp.RequestInfo}}, nil
 	}
 
 	// Otherwise, try to update an existing bucket definition
@@ -307,20 +310,21 @@ func (c Client) upsert(ctx context.Context, bucketName string, data []byte) (Res
 			return Response{api.Response{
 				StatusCode: resp.StatusCode,
 				Data:       resp.Payload,
+				Request:    resp.RequestInfo,
 			}}, nil
 		}
 
 		if resp.IsSuccess() {
 			// Update operation was successful
 			logger.Info(fmt.Sprintf("Updated bucket with bucket name %q", bucketName))
-			return Response{api.Response{StatusCode: resp.StatusCode, Data: resp.Payload}}, nil
+			return Response{api.Response{StatusCode: resp.StatusCode, Data: resp.Payload, Request: resp.RequestInfo}}, nil
 		}
 
 		time.Sleep(waitDuration)
 	}
 
 	// All retries failed, return the last Response and error
-	return Response{api.Response{StatusCode: resp.StatusCode, Data: resp.Payload}}, err
+	return Response{api.Response{StatusCode: resp.StatusCode, Data: resp.Payload, Request: resp.RequestInfo}}, err
 }
 
 func (c Client) create(ctx context.Context, bucketName string, data []byte) (rest.Response, error) {
@@ -436,5 +440,6 @@ func unmarshalJSONList(raw *rest.Response) (listResponse, error) {
 	}
 	r.Data = raw.Payload
 	r.StatusCode = raw.StatusCode
+	r.Request = raw.RequestInfo
 	return r, nil
 }

--- a/api/rest/client.go
+++ b/api/rest/client.go
@@ -222,7 +222,13 @@ func (c *Client) sendRequestWithRetries(ctx context.Context, method string, endp
 		logger.V(1).Error(err, "Failed to close response body of failed request")
 	}
 
-	return Response{Payload: payload, StatusCode: response.StatusCode}, nil
+	return Response{
+		Payload:    payload,
+		StatusCode: response.StatusCode,
+		RequestInfo: RequestInfo{
+			Method: req.Method,
+			URL:    req.URL.String(),
+		}}, nil
 }
 
 func isConnectionResetErr(err error) bool {

--- a/api/rest/response.go
+++ b/api/rest/response.go
@@ -21,6 +21,9 @@ type Response struct {
 
 	// StatusCode is the HTTP status code of the response.
 	StatusCode int
+
+	// RequestInfo holds information about the original request that led to this response
+	RequestInfo RequestInfo
 }
 
 // IsSuccess returns true if the response indicates a successful HTTP status code.
@@ -39,4 +42,10 @@ func (resp Response) Is4xxError() bool {
 // A status code between 500 and 599 (inclusive) is considered a server error.
 func (resp Response) Is5xxError() bool {
 	return resp.StatusCode >= 500 && resp.StatusCode <= 599
+}
+
+// RequestInfo holds information about the original request that led to this response
+type RequestInfo struct {
+	Method string `json:"method"` // The HTTP method of the request.
+	URL    string `json:"url"`    // The full URL of the request
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code-core/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
Often you want to treat API responses (4xx,5xx) as a real go error. I've introduced the AsAPIError method on response which enables just that.

```go
if err, ok := response.AsAPIError(); ok {
  //do something wit api err
}
```


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
