### PR TITLE
fix: Bucket CLient increase fixed retries from 3 to 5

### DIFF
--- a/api/clients/buckets/bucket.go
+++ b/api/clients/buckets/bucket.go
@@ -182,7 +182,7 @@ func (c Client) Update(ctx context.Context, bucketName string, data []byte) (Res
 
 	logger := logr.FromContextOrDiscard(ctx)
 
-	maxRetries := 3
+	maxRetries := 5
 	waitDuration := time.Second
 
 	var resp rest.Response
@@ -291,7 +291,7 @@ func (c Client) upsert(ctx context.Context, bucketName string, data []byte) (Res
 
 	// Otherwise, try to update an existing bucket definition
 	logger.V(1).Info(fmt.Sprintf("Failed to create new object with bucket name %q. Trying to update existing object. API Error (HTTP %d): %s", bucketName, resp.StatusCode, resp.Payload))
-	maxRetries := 3
+	maxRetries := 5
 	waitDuration := time.Second
 	for i := 0; i < maxRetries; i++ {
 		logger.V(1).Info(fmt.Sprintf("Trying to update bucket with bucket name %q (%d/%d retries)", bucketName, i+1, maxRetries))


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code-core/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
In e2e tests we saw that 3 retires were not enough and one of the bucket tests fails occasionally, hence this number is slightly increased to 5. Maybe we should also think about making this configureable
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
