### PR TITLE
Fix/bucket updates

### DIFF
--- a/api/clients/buckets/bucket_test.go
+++ b/api/clients/buckets/bucket_test.go
@@ -349,7 +349,9 @@ func TestUpsert(t *testing.T) {
 		server := testutils.NewHTTPTestServer(t, responses)
 		defer server.Close()
 
-		client := buckets.NewClient(rest.NewClient(server.URL(), server.Client()))
+		client := buckets.NewClient(
+			rest.NewClient(server.URL(), server.Client()),
+			buckets.WithUpdateRetrySettings(5, 0))
 		data := []byte("{}")
 
 		ctx := testutils.ContextWithLogger(t)
@@ -373,7 +375,9 @@ func TestUpsert(t *testing.T) {
 		server := testutils.NewHTTPTestServer(t, responses)
 		defer server.Close()
 
-		client := buckets.NewClient(rest.NewClient(server.URL(), server.Client()))
+		client := buckets.NewClient(
+			rest.NewClient(server.URL(), server.Client()),
+			buckets.WithUpdateRetrySettings(5, 0))
 		data := []byte("{}")
 
 		ctx := testutils.ContextWithLogger(t)
@@ -688,7 +692,9 @@ func TestUpdate(t *testing.T) {
 		server := testutils.NewHTTPTestServer(t, responses)
 		defer server.Close()
 
-		client := buckets.NewClient(rest.NewClient(server.URL(), &http.Client{}))
+		client := buckets.NewClient(
+			rest.NewClient(server.URL(), server.Client()),
+			buckets.WithUpdateRetrySettings(5, 0))
 		data := []byte("{}")
 
 		ctx := testutils.ContextWithLogger(t)

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ module github.com/dynatrace/dynatrace-configuration-as-code-core
 
 require (
 	github.com/go-logr/logr v1.2.4
+	github.com/google/go-cmp v0.5.9
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/oauth2 v0.11.0
 	golang.org/x/time v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,7 @@ github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=


### PR DESCRIPTION
#### What this PR does / Why we need it:

- [fix(buckets): Only attempt update when upserting if create failed with a conflict](https://github.com/Dynatrace/dynatrace-configuration-as-code-core/pull/25/commits/3f504a43a3cadc8113b7e51fe74a04d718319714)
- [feat(buckets): Do not update buckets if they are unmodified](https://github.com/Dynatrace/dynatrace-configuration-as-code-core/pull/25/commits/0b4aff799f4164c0e890847f796afcce3d06e1e5)

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?

- An update is only attempted on Upsert if creation failed with a conflict, any other errors like permissions or bad payloads are returned immediately, and no longer hidden behind a likely subsequent GET error when trying to update.
- Upsert and Update no longer update an object if the existing values are the same as what they would be updated to. From an interface perspective, nothing changes and users are still supplied with a 200 Response with empty payload, same as what the Dynatrace API returns.
