### PR TITLE
feat: introduce api client for automation resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ happen either prior to making the actual HTTP calls or if the HTTP calls couldn'
 |---------------------|-------------|
 | Classic config APIs | ❌           |
 | Settings 2.0        | ❌           |
-| Automation          | ❌           |
+| Automation          | ✅           |
 | Grail buckets       | ✅           |
 
 

--- a/api/clients/automation/automation.go
+++ b/api/clients/automation/automation.go
@@ -66,11 +66,11 @@ var resources = map[ResourceType]Resource{
 //
 // Parameters:
 //
-//   - client (*rest.Client): A REST client used for making HTTP requests to interact with automation resources.
+//   - client: A REST client used for making HTTP requests to interact with automation resources.
 //
 // Returns:
 //
-//   - c (*Client): A new instance of the Client type initialized with the provided REST client and resources.
+//   - *Client: A new instance of the Client type initialized with the provided REST client and resources.
 func NewClient(client *rest.Client) *Client {
 	c := &Client{
 		client:    client,
@@ -96,15 +96,15 @@ type ClientOption func(*Client)
 //
 // Parameters:
 //
-//   - ctx (context.Context): The context for the HTTP request.
-//   - resourceType (ResourceType): The type of the resource to retrieve.
-//   - id (string): The unique identifier of the object to retrieve.
+//   - ctx: The context for the HTTP request.
+//   - resourceType: The type of the resource to retrieve.
+//   - id: The unique identifier of the object to retrieve.
 //
 // Returns:
 //
-//	(Response, error): A Response object containing information about the HTTP response
-//	and an error, if any.
-func (a Client) Get(ctx context.Context, resourceType ResourceType, id string) (result Response, err error) {
+//   - Response: A Response containing the result of the HTTP operation, including status code and data.
+//   - error: An error if the HTTP call fails or another error happened.
+func (a Client) Get(ctx context.Context, resourceType ResourceType, id string) (Response, error) {
 	if id == "" {
 		return Response{}, fmt.Errorf("id must be non empty")
 	}
@@ -124,14 +124,14 @@ func (a Client) Get(ctx context.Context, resourceType ResourceType, id string) (
 //
 // Parameters:
 //
-//   - ctx (context.Context): The context for the HTTP request.
-//   - resourceType (ResourceType): The type of the resource to retrieve.
-//   - data ([]byte): the data of the resource
+//   - ctx: The context for the HTTP request.
+//   - resourceType: The type of the resource to retrieve.
+//   - data: the data of the resource
 //
 // Returns:
 //
-//	(Response, error): A Response object containing information about the HTTP response
-//	and an error, if any.
+//   - Response: A Response containing the result of the HTTP operation, including status code and data.
+//   - error: An error if the HTTP call fails or another error happened.
 func (a Client) Create(ctx context.Context, resourceType ResourceType, data []byte) (result Response, err error) {
 	return a.create(ctx, data, resourceType)
 }
@@ -140,15 +140,15 @@ func (a Client) Create(ctx context.Context, resourceType ResourceType, data []by
 //
 // Parameters:
 //
-//   - ctx (context.Context): The context for the HTTP request.
-//   - resourceType (ResourceType): The type of the resource to retrieve.
-//   - id (string): the id of the resource to be updated
-//   - data ([]byte): the updated data
+//   - ctx: The context for the HTTP request.
+//   - resourceType: The type of the resource to retrieve.
+//   - id: the id of the resource to be updated
+//   - data: the updated data
 //
 // Returns:
 //
-//	(Response, error): A Response object containing information about the HTTP response
-//	and an error, if any.
+//   - Response: A Response containing the result of the HTTP operation, including status code and data.
+//   - error: An error if the HTTP call fails or another error happened.
 func (a Client) Update(ctx context.Context, resourceType ResourceType, id string, data []byte) (Response, error) {
 	return a.update(ctx, resourceType, id, data)
 }
@@ -163,13 +163,13 @@ func (a Client) Update(ctx context.Context, resourceType ResourceType, id string
 // from each paginated request are stored as byte slices within the ListResponse.
 //
 // Parameters:
-//   - ctx (context.Context): A context.Context for controlling the request lifecycle.
-//   - resourceType (ResourceType): The type of resource to list.
+//   - ctx: A context.Context for controlling the request lifecycle.
+//   - resourceType: The type of resource to list.
 //
 // Returns:
 //
-//	(Response, error): A Response object containing information about the HTTP response
-//	and an error, if any.
+//   - ListResponse: A ListResponse which is an api.PagedListResponse containing all objects fetched from the api
+//   - error: An error if the HTTP call fails or another error happened.
 func (a Client) List(ctx context.Context, resourceType ResourceType) (ListResponse, error) {
 	var retVal ListResponse
 	var result listResponse
@@ -232,15 +232,15 @@ func (a Client) List(ctx context.Context, resourceType ResourceType) (ListRespon
 // Upsert creates or updates an object of a specified resource type with the given ID and data.
 //
 // Parameters:
-//   - ctx (context.Context): The context for the HTTP request.
-//   - resourceType (ResourceType): The type of the resource to upsert.
-//   - id (string): The unique identifier for the object.
-//   - data ([]byte): The data payload representing the object.
+//   - ctx: The context for the HTTP request.
+//   - resourceType: The type of the resource to upsert.
+//   - id: The unique identifier for the object.
+//   - data: The data payload representing the object.
 //
 // Returns:
 //
-//	(Response, error): A Response object containing information about the HTTP response
-//	and an error, if any.
+//   - Response: A Response containing the result of the HTTP operation, including status code and data.
+//   - error: An error if the HTTP call fails or another error happened.
 func (a Client) Upsert(ctx context.Context, resourceType ResourceType, id string, data []byte) (result Response, err error) {
 	if id == "" {
 		return Response{}, fmt.Errorf("id must be non empty")
@@ -264,13 +264,14 @@ func (a Client) Upsert(ctx context.Context, resourceType ResourceType, id string
 // the request without the "adminAccess" parameter.
 //
 // Parameters:
-//   - ctx (context.Context): A context.Context for controlling the request lifecycle.
-//   - resourceType (ResourceType): The type of resource from which to delete the object.
-//   - id (string): The unique identifier (ID) of the object to delete.
+//   - ctx: A context.Context for controlling the request lifecycle.
+//   - resourceType: The type of resource from which to delete the object.
+//   - id: The unique identifier (ID) of the object to delete.
 //
 // Returns:
 //
-//	(Response, error): A Response object containing information about the HTTP response and an error, if any.
+//   - Response: A Response containing the result of the HTTP operation, including status code and data.
+//   - error: An error if the HTTP call fails or another error happened.
 func (a Client) Delete(ctx context.Context, resourceType ResourceType, id string) (Response, error) {
 	if id == "" {
 		return Response{}, fmt.Errorf("id must be non empty")

--- a/api/clients/automation/automation.go
+++ b/api/clients/automation/automation.go
@@ -1,0 +1,361 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package automation
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
+	"net/http"
+	"net/url"
+	"strconv"
+)
+
+type Response struct {
+	api.Response
+}
+
+// PagedListResponse contains multiple ListResponse values
+type PagedListResponse []ListResponse
+
+// Objects returns all objects of a PagedListResponse
+func (p *PagedListResponse) Objects() [][]byte {
+	var ret [][]byte
+	for _, l := range []ListResponse(*p) {
+		for _, o := range l.Objects {
+			ret = append(ret, o)
+		}
+	}
+	return ret
+}
+
+type ListResponse struct {
+	api.ListResponse
+}
+
+type listResponse struct {
+	api.Response
+	Count   int               `json:"count"`
+	Objects []json.RawMessage `json:"results"`
+}
+
+// Resource specifies information about a specific resource
+type Resource struct {
+	// Path is the API path to be used for this resource
+	Path string
+}
+
+// ResourceType enumerates different kind of resources
+type ResourceType int
+
+const (
+	Workflows ResourceType = iota
+	BusinessCalendars
+	SchedulingRules
+)
+
+var resources = map[ResourceType]Resource{
+	Workflows:         {Path: "/platform/automation/v1/workflows"},
+	BusinessCalendars: {Path: "/platform/automation/v1/business-calendars"},
+	SchedulingRules:   {Path: "/platform/automation/v1/scheduling-rules"},
+}
+
+// NewClient creates and returns a new instance a client which is used for interacting
+// with automation resources.
+//
+// Parameters:
+//
+//   - client (*rest.Client): A REST client used for making HTTP requests to interact with automation resources.
+//
+// Returns:
+//
+//   - c (*Client): A new instance of the Client type initialized with the provided REST client and resources.
+func NewClient(client *rest.Client) *Client {
+	c := &Client{
+		client:    client,
+		resources: resources,
+	}
+
+	return c
+}
+
+// Client can be used to interact with the Automation API
+type Client struct {
+	client    *rest.Client
+	resources map[ResourceType]Resource
+}
+
+// ClientOption are (optional) additional parameter passed to the creation of
+// an automation client
+type ClientOption func(*Client)
+
+// Get retrieves a single automation object based on the specified resource type and ID.
+//
+// It checks if the ID is non-empty, and if not, returns an error.
+//
+// Parameters:
+//
+//	ctx (context.Context): The context for the HTTP request.
+//	resourceType (ResourceType): The type of the resource to retrieve.
+//	id (string): The unique identifier of the object to retrieve.
+//
+// Returns:
+//
+//	result (Response): A Response object containing the retrieved object and its metadata.
+//	err (error): An error if the retrieval operation fails or if the ID is empty.
+func (a Client) Get(ctx context.Context, resourceType ResourceType, id string) (result Response, err error) {
+	if id == "" {
+		return Response{}, fmt.Errorf("id must be non empty")
+	}
+	path, err := url.JoinPath(a.resources[resourceType].Path, id)
+	if err != nil {
+		return Response{}, fmt.Errorf("failed to create URL: %w", err)
+	}
+	resp, err := a.client.GET(ctx, path, rest.RequestOptions{})
+	if err != nil {
+		return Response{}, fmt.Errorf("failed to get automation resource of type %q with id %q: %w", resourceType, id, err)
+	}
+
+	return Response{api.Response{StatusCode: resp.StatusCode, Data: resp.Payload, Request: resp.RequestInfo}}, nil
+}
+
+// List retrieves a list of automation objects of the specified resource
+//
+// The function sends multiple HTTP GET requests to fetch paginated data. It continues making requests
+// until the total number of objects retrieved matches the expected count provided by the server.
+//
+// The result is returned as a slice of ListResponse objects. Each ListResponse contains information about
+// the HTTP response, including the status code, response data, and request details. The objects retrieved
+// from each paginated request are stored as byte slices within the ListResponse.
+//
+// Parameters:
+//   - ctx (context.Context): A context.Context for controlling the request lifecycle.
+//   - resourceType (ResourceType): The type of resource to list.
+//
+// Returns:
+//
+//	(Response, error): A Response object containing information about the HTTP response
+//	and an error, if any.
+func (a Client) List(ctx context.Context, resourceType ResourceType) (PagedListResponse, error) {
+
+	var retVal []ListResponse
+	var result listResponse
+	result.Count = 1
+
+	getCount := func(l []ListResponse) int {
+		var count int
+		for _, r := range l {
+			count += len(r.Objects)
+		}
+		return count
+	}
+
+	for getCount(retVal) < result.Count {
+		resp, err := a.client.GET(ctx, a.resources[resourceType].Path, rest.RequestOptions{
+			QueryParams: url.Values{"offset": []string{strconv.Itoa(len(retVal))}}},
+		)
+
+		if err != nil {
+			return []ListResponse{}, fmt.Errorf("failed to list buckets:%w", err)
+		}
+
+		// if one of the response has code != 2xx return empty list with response info
+		if !resp.IsSuccess() {
+			return []ListResponse{{
+				api.ListResponse{
+					Response: api.Response{
+						StatusCode: resp.StatusCode,
+						Data:       resp.Payload,
+						Request:    resp.RequestInfo,
+					},
+					Objects: nil,
+				},
+			}}, nil
+		}
+
+		result, err = unmarshalJSONList(&resp)
+		if err != nil {
+			return []ListResponse{}, fmt.Errorf("failed to parse list response:%w", err)
+		}
+
+		b := make([][]byte, len(result.Objects))
+		for i, v := range result.Objects {
+			b[i], _ = v.MarshalJSON() // marshalling the JSON back to JSON will not fail
+		}
+
+		retVal = append(retVal, ListResponse{api.ListResponse{
+			Response: api.Response{
+				StatusCode: result.StatusCode,
+				Data:       result.Data,
+				Request:    result.Request,
+			},
+			Objects: b,
+		}})
+
+	}
+
+	return retVal, nil
+
+}
+
+// Upsert creates or updates an object of a specified resource type with the given ID and data.
+//
+// Parameters:
+//   - ctx (context.Context): The context for the HTTP request.
+//   - resourceType (ResourceType): The type of the resource to upsert.
+//   - id (string): The unique identifier for the object.
+//   - data ([]byte): The data payload representing the object.
+//
+// Returns:
+//
+//	(Response, error): A Response object containing information about the HTTP response
+//	and an error, if any.
+func (a Client) Upsert(ctx context.Context, resourceType ResourceType, id string, data []byte) (result Response, err error) {
+	if id == "" {
+		return Response{}, fmt.Errorf("id must be non empty")
+	}
+	if err := rmIDField(&data); err != nil {
+		return Response{}, fmt.Errorf("unable to remove id field from payload in order to update object with ID %s: %w", id, err)
+	}
+
+	path, err := url.JoinPath(a.resources[resourceType].Path, id)
+	if err != nil {
+		return Response{}, fmt.Errorf("failed to create URL: %w", err)
+	}
+
+	workflowsAdminAccess := resourceType == Workflows
+
+	resp, err := a.client.PUT(ctx, path, bytes.NewReader(data), rest.RequestOptions{
+		QueryParams: url.Values{"adminAccess": []string{strconv.FormatBool(workflowsAdminAccess)}},
+	})
+	if err != nil {
+		return Response{}, fmt.Errorf("unable to update object with ID %s: %w", id, err)
+	}
+
+	if workflowsAdminAccess && resp.StatusCode == http.StatusForbidden {
+
+		resp, err = a.client.PUT(ctx, path, bytes.NewReader(data), rest.RequestOptions{})
+		if err != nil {
+			return Response{}, fmt.Errorf("unable to update object with ID %s: %w", id, err)
+		}
+	}
+
+	if resp.IsSuccess() {
+		return Response{api.Response{StatusCode: resp.StatusCode, Data: resp.Payload, Request: resp.RequestInfo}}, nil
+	}
+
+	// at this point we need to create a new object using HTTP POST
+	return a.create(ctx, id, data, resourceType)
+}
+
+func (a Client) create(ctx context.Context, id string, data []byte, resourceType ResourceType) (Response, error) {
+	// make sure actual "id" field is set in payload
+	if err := setIDField(id, &data); err != nil {
+		return Response{}, fmt.Errorf("unable to set the id field in order to crate object with id %s: %w", id, err)
+	}
+
+	resp, err := a.client.POST(ctx, a.resources[resourceType].Path, bytes.NewReader(data), rest.RequestOptions{})
+	if err != nil {
+		return Response{}, err
+	}
+
+	return Response{api.Response{StatusCode: resp.StatusCode, Data: resp.Payload, Request: resp.RequestInfo}}, nil
+}
+
+// Delete removes an automation object of the specified resource type by its unique identifier (ID).
+//
+// If the initial DELETE request results in a forbidden status code (HTTP 403) for Workflows, it retries
+// the request without the "adminAccess" parameter.
+//
+// Parameters:
+//   - ctx (context.Context): A context.Context for controlling the request lifecycle.
+//   - resourceType (ResourceType): The type of resource from which to delete the object.
+//   - id (string): The unique identifier (ID) of the object to delete.
+//
+// Returns:
+//
+//	(Response, error): A Response object containing information about the HTTP response and an error, if any.
+func (a Client) Delete(ctx context.Context, resourceType ResourceType, id string) (Response, error) {
+	if id == "" {
+		return Response{}, fmt.Errorf("id must be non empty")
+	}
+	path, err := url.JoinPath(a.resources[resourceType].Path, id)
+	if err != nil {
+		return Response{}, fmt.Errorf("failed to create URL: %w", err)
+	}
+
+	workflowsAdminAccess := resourceType == Workflows
+
+	resp, err := a.client.DELETE(ctx, path, rest.RequestOptions{
+		QueryParams: url.Values{"adminAccess": []string{strconv.FormatBool(workflowsAdminAccess)}},
+	})
+	if err != nil {
+		return Response{}, fmt.Errorf("unable to delete object with ID %s: %w", id, err)
+	}
+
+	if workflowsAdminAccess && resp.StatusCode == http.StatusForbidden {
+		resp, err = a.client.DELETE(ctx, path, rest.RequestOptions{})
+		if err != nil {
+			return Response{}, fmt.Errorf("unable to delete object with ID %s: %w", id, err)
+		}
+	}
+	return Response{api.Response{StatusCode: resp.StatusCode, Data: resp.Payload, Request: resp.RequestInfo}}, nil
+}
+
+// unmarshalJSONList unmarshals JSON data into a listResponse struct.
+func unmarshalJSONList(raw *rest.Response) (listResponse, error) {
+	var r listResponse
+	err := json.Unmarshal(raw.Payload, &r)
+	if err != nil {
+		return listResponse{}, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+	r.Data = raw.Payload
+	r.StatusCode = raw.StatusCode
+	r.Request = raw.RequestInfo
+	return r, nil
+}
+
+func setIDField(id string, data *[]byte) error {
+	var m map[string]interface{}
+	err := json.Unmarshal(*data, &m)
+	if err != nil {
+		return err
+	}
+	m["id"] = id
+	*data, err = json.Marshal(m)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func rmIDField(data *[]byte) error {
+	var m map[string]interface{}
+	err := json.Unmarshal(*data, &m)
+	if err != nil {
+		return err
+	}
+	delete(m, "id")
+	*data, err = json.Marshal(m)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/api/clients/automation/automation_test.go
+++ b/api/clients/automation/automation_test.go
@@ -1,0 +1,540 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package automation_test
+
+import (
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/clients/automation"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/internal/testutils"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"testing"
+)
+
+func TestAutomationClient_Get(t *testing.T) {
+	const payload = `{ "id" : "91cc8988-2223-404a-a3f5-5f1a839ecd45", "data" : "some-data1" }`
+
+	t.Run("Get - no ID given", func(t *testing.T) {
+		responses := testutils.ServerResponses{}
+		server := testutils.NewHTTPTestServer(t, []testutils.ServerResponses{responses})
+		defer server.Close()
+
+		client := automation.NewClient(rest.NewClient(server.URL(), server.Client()))
+		ctx := testutils.ContextWithLogger(t)
+		resp, err := client.Get(ctx, automation.Workflows, "")
+		assert.Zero(t, resp)
+		assert.NotNil(t, err)
+	})
+
+	t.Run("GET - OK", func(t *testing.T) {
+
+		responses := testutils.ServerResponses{
+			http.MethodGet: {
+				ResponseCode: http.StatusOK,
+				ResponseBody: payload,
+			},
+		}
+		server := testutils.NewHTTPTestServer(t, []testutils.ServerResponses{responses})
+		defer server.Close()
+
+		client := automation.NewClient(rest.NewClient(server.URL(), server.Client()))
+
+		ctx := testutils.ContextWithLogger(t)
+		resp, err := client.Get(ctx, automation.Workflows, "91cc8988-2223-404a-a3f5-5f1a839ecd45")
+		assert.NotNil(t, resp)
+		assert.Equal(t, payload, string(resp.Data))
+		assert.NoError(t, err)
+	})
+
+	t.Run("GET - Unable to make HTTP call", func(t *testing.T) {
+		responses := testutils.ServerResponses{}
+		server := testutils.NewHTTPTestServer(t, []testutils.ServerResponses{responses})
+		defer server.Close()
+
+		client := automation.NewClient(rest.NewClient(server.URL(), server.FaultyClient()))
+		ctx := testutils.ContextWithLogger(t)
+		resp, err := client.Get(ctx, automation.Workflows, "91cc8988-2223-404a-a3f5-5f1a839ecd45")
+		assert.Zero(t, resp)
+		assert.Error(t, err)
+	})
+
+	t.Run("GET - API Call returned with != 2xx", func(t *testing.T) {
+		responses := testutils.ServerResponses{
+			http.MethodGet: {
+				ResponseCode: http.StatusBadRequest,
+			},
+		}
+		server := testutils.NewHTTPTestServer(t, []testutils.ServerResponses{responses})
+		defer server.Close()
+
+		client := automation.NewClient(rest.NewClient(server.URL(), server.Client()))
+		ctx := testutils.ContextWithLogger(t)
+		resp, err := client.Get(ctx, automation.Workflows, "91cc8988-2223-404a-a3f5-5f1a839ecd45")
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		assert.NoError(t, err)
+	})
+}
+
+func TestAutomationClient_Upsert(t *testing.T) {
+
+	_ = `{"id" : "91cc8988-2223-404a-a3f5-5f1a839ecd45", "data" : "some-data"}`
+
+	t.Run("Upsert - no ID given", func(t *testing.T) {
+		responses := testutils.ServerResponses{}
+		server := testutils.NewHTTPTestServer(t, []testutils.ServerResponses{responses})
+		defer server.Close()
+
+		client := automation.NewClient(rest.NewClient(server.URL(), server.Client()))
+		ctx := testutils.ContextWithLogger(t)
+		resp, err := client.Upsert(ctx, automation.Workflows, "", []byte{})
+		assert.Zero(t, resp)
+		assert.NotNil(t, err)
+	})
+
+	t.Run("Upsert - invalid data", func(t *testing.T) {
+		responses := testutils.ServerResponses{}
+		server := testutils.NewHTTPTestServer(t, []testutils.ServerResponses{responses})
+		defer server.Close()
+
+		client := automation.NewClient(rest.NewClient(server.URL(), server.Client()))
+		ctx := testutils.ContextWithLogger(t)
+		resp, err := client.Upsert(ctx, automation.Workflows, "91cc8988-2223-404a-a3f5-5f1a839ecd45", []byte{})
+		assert.Zero(t, resp)
+		assert.NotNil(t, err)
+	})
+
+	t.Run("Upsert - not able to make HTTP PUT call", func(t *testing.T) {
+		responses := testutils.ServerResponses{
+			http.MethodPut: {
+				ResponseCode: http.StatusBadRequest,
+				ResponseBody: "{}",
+			},
+		}
+
+		server := testutils.NewHTTPTestServer(t, []testutils.ServerResponses{responses})
+		defer server.Close()
+
+		client := automation.NewClient(rest.NewClient(server.URL(), server.FaultyClient()))
+		ctx := testutils.ContextWithLogger(t)
+		data := []byte(`{"id" : "some-id"}`)
+		resp, err := client.Upsert(ctx, automation.Workflows, "91cc8988-2223-404a-a3f5-5f1a839ecd45", data)
+		assert.Zero(t, resp)
+		assert.NotNil(t, err)
+	})
+
+	t.Run("Upsert - adminAccess query parameter set for workflows", func(t *testing.T) {
+		responses := []testutils.ServerResponses{{
+			http.MethodPut: {
+				ResponseCode: http.StatusOK,
+				ResponseBody: "{}",
+				ValidateRequestFunc: func(request *http.Request) {
+					adminAccessQP := request.URL.Query()["adminAccess"]
+					assert.Len(t, adminAccessQP, 1)
+					assert.Equal(t, "true", adminAccessQP[0])
+
+				},
+			},
+		},
+			{
+				http.MethodPut: {
+					ResponseCode: http.StatusOK,
+					ResponseBody: "{}",
+					ValidateRequestFunc: func(request *http.Request) {
+						adminAccessQP := request.URL.Query()["adminAccess"]
+						assert.Len(t, adminAccessQP, 1)
+						assert.Equal(t, "false", adminAccessQP[0])
+					},
+				},
+			}}
+
+		server := testutils.NewHTTPTestServer(t, responses)
+		defer server.Close()
+
+		client := automation.NewClient(rest.NewClient(server.URL(), server.Client()))
+		client.Upsert(testutils.ContextWithLogger(t), automation.Workflows, "91cc8988-2223-404a-a3f5-5f1a839ecd45", []byte(`{"id" : "some-id"}`))
+		client.Upsert(testutils.ContextWithLogger(t), automation.BusinessCalendars, "91cc8988-2223-404a-a3f5-5f1a839ecd45", []byte(`{"id" : "some-id"}`))
+	})
+
+	t.Run("Upsert - adminAccess forbidden", func(t *testing.T) {
+		responses := []testutils.ServerResponses{{
+			http.MethodPut: {
+				ResponseCode: http.StatusForbidden,
+				ResponseBody: "{}",
+				ValidateRequestFunc: func(request *http.Request) {
+					adminAccessQP := request.URL.Query()["adminAccess"]
+					assert.Len(t, adminAccessQP, 1)
+					assert.Equal(t, "true", adminAccessQP[0])
+				},
+			},
+		}, {
+			http.MethodPut: {
+				ResponseCode: http.StatusOK,
+				ResponseBody: "{}",
+				ValidateRequestFunc: func(request *http.Request) {
+					adminAccessQP := request.URL.Query()["adminAccess"]
+					assert.Len(t, adminAccessQP, 0)
+				},
+			},
+		}}
+
+		server := testutils.NewHTTPTestServer(t, responses)
+		defer server.Close()
+
+		client := automation.NewClient(rest.NewClient(server.URL(), server.Client()))
+		ctx := testutils.ContextWithLogger(t)
+		data := []byte(`{"id" : "some-id"}`)
+		resp, err := client.Upsert(ctx, automation.Workflows, "91cc8988-2223-404a-a3f5-5f1a839ecd45", data)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, 2, server.Calls())
+		assert.Nil(t, err)
+	})
+
+	t.Run("Upsert - Direct update using HTTP PUT API Call returned with != 2xx- creation via POST fails", func(t *testing.T) {
+		responses := []testutils.ServerResponses{{
+			http.MethodPut: {
+				ResponseCode: http.StatusForbidden,
+				ResponseBody: "{}",
+			},
+		}, {
+			http.MethodPut: {
+				ResponseCode: http.StatusNotFound,
+				ResponseBody: "{}",
+			},
+		}, {
+			http.MethodPost: {
+				ResponseCode: http.StatusInternalServerError,
+				ResponseBody: "{}",
+			},
+		}}
+
+		server := testutils.NewHTTPTestServer(t, responses)
+		defer server.Close()
+
+		client := automation.NewClient(rest.NewClient(server.URL(), server.Client()))
+		ctx := testutils.ContextWithLogger(t)
+		data := []byte(`{"id" : "some-id"}`)
+		resp, err := client.Upsert(ctx, automation.Workflows, "91cc8988-2223-404a-a3f5-5f1a839ecd45", data)
+		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+		assert.Equal(t, 3, server.Calls())
+		assert.Nil(t, err)
+	})
+
+	t.Run("Upsert - Direct update using HTTP PUT API Call returned with != 2xx - creation via POST OK", func(t *testing.T) {
+		responses := []testutils.ServerResponses{{
+			http.MethodPut: {
+				ResponseCode: http.StatusForbidden,
+				ResponseBody: "{}",
+			},
+		}, {
+			http.MethodPut: {
+				ResponseCode: http.StatusNotFound,
+				ResponseBody: "{}",
+			},
+		}, {
+			http.MethodPost: {
+				ResponseCode: http.StatusCreated,
+				ResponseBody: "{}",
+			},
+		}}
+
+		server := testutils.NewHTTPTestServer(t, responses)
+		defer server.Close()
+
+		client := automation.NewClient(rest.NewClient(server.URL(), server.Client()))
+		ctx := testutils.ContextWithLogger(t)
+		data := []byte(`{"id" : "some-id"}`)
+		resp, err := client.Upsert(ctx, automation.Workflows, "91cc8988-2223-404a-a3f5-5f1a839ecd45", data)
+		assert.Equal(t, http.StatusCreated, resp.StatusCode)
+		assert.Equal(t, 3, server.Calls())
+		assert.Nil(t, err)
+	})
+}
+
+func TestAutomationClient_Delete(t *testing.T) {
+	t.Run("Delete - no ID given", func(t *testing.T) {
+		responses := testutils.ServerResponses{}
+		server := testutils.NewHTTPTestServer(t, []testutils.ServerResponses{responses})
+		defer server.Close()
+
+		client := automation.NewClient(rest.NewClient(server.URL(), server.Client()))
+		ctx := testutils.ContextWithLogger(t)
+		resp, err := client.Delete(ctx, automation.Workflows, "")
+		assert.Zero(t, resp)
+		assert.NotNil(t, err)
+	})
+
+	t.Run("Delete - HTTP Call fails", func(t *testing.T) {
+		responses := testutils.ServerResponses{}
+		server := testutils.NewHTTPTestServer(t, []testutils.ServerResponses{responses})
+		defer server.Close()
+
+		client := automation.NewClient(rest.NewClient(server.URL(), server.FaultyClient()))
+		ctx := testutils.ContextWithLogger(t)
+		resp, err := client.Delete(ctx, automation.Workflows, "")
+		assert.Zero(t, resp)
+		assert.NotNil(t, err)
+	})
+
+	t.Run("Delete - adminAccess query parameter set for workflows", func(t *testing.T) {
+		responses := []testutils.ServerResponses{{
+			http.MethodDelete: {
+				ResponseCode: http.StatusOK,
+				ResponseBody: "{}",
+				ValidateRequestFunc: func(request *http.Request) {
+					adminAccessQP := request.URL.Query()["adminAccess"]
+					assert.Len(t, adminAccessQP, 1)
+					assert.Equal(t, "true", adminAccessQP[0])
+
+				},
+			},
+		},
+			{
+				http.MethodDelete: {
+					ResponseCode: http.StatusOK,
+					ResponseBody: "{}",
+					ValidateRequestFunc: func(request *http.Request) {
+						adminAccessQP := request.URL.Query()["adminAccess"]
+						assert.Len(t, adminAccessQP, 1)
+						assert.Equal(t, "false", adminAccessQP[0])
+					},
+				},
+			}}
+
+		server := testutils.NewHTTPTestServer(t, responses)
+		defer server.Close()
+
+		client := automation.NewClient(rest.NewClient(server.URL(), server.Client()))
+		client.Delete(testutils.ContextWithLogger(t), automation.Workflows, "91cc8988-2223-404a-a3f5-5f1a839ecd45")
+		client.Delete(testutils.ContextWithLogger(t), automation.BusinessCalendars, "91cc8988-2223-404a-a3f5-5f1a839ecd45")
+	})
+
+	t.Run("Delete - adminAccess forbidden", func(t *testing.T) {
+		responses := []testutils.ServerResponses{{
+			http.MethodDelete: {
+				ResponseCode: http.StatusForbidden,
+				ResponseBody: "{}",
+				ValidateRequestFunc: func(request *http.Request) {
+					adminAccessQP := request.URL.Query()["adminAccess"]
+					assert.Len(t, adminAccessQP, 1)
+					assert.Equal(t, "true", adminAccessQP[0])
+				},
+			},
+		}, {
+			http.MethodDelete: {
+				ResponseCode: http.StatusOK,
+				ResponseBody: "{}",
+				ValidateRequestFunc: func(request *http.Request) {
+					adminAccessQP := request.URL.Query()["adminAccess"]
+					assert.Len(t, adminAccessQP, 0)
+				},
+			},
+		}}
+
+		server := testutils.NewHTTPTestServer(t, responses)
+		defer server.Close()
+
+		client := automation.NewClient(rest.NewClient(server.URL(), server.Client()))
+		ctx := testutils.ContextWithLogger(t)
+		resp, err := client.Delete(ctx, automation.Workflows, "91cc8988-2223-404a-a3f5-5f1a839ecd45")
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, 2, server.Calls())
+		assert.Nil(t, err)
+	})
+
+	t.Run("Delete - adminAccess forbidden - DELETE API Call returned with != 2xx", func(t *testing.T) {
+		responses := []testutils.ServerResponses{{
+			http.MethodDelete: {
+				ResponseCode: http.StatusForbidden,
+				ResponseBody: "{}",
+			},
+		}, {
+			http.MethodDelete: {
+				ResponseCode: http.StatusInternalServerError,
+				ResponseBody: "{}",
+			},
+		}}
+
+		server := testutils.NewHTTPTestServer(t, responses)
+		defer server.Close()
+
+		client := automation.NewClient(rest.NewClient(server.URL(), server.Client()))
+		ctx := testutils.ContextWithLogger(t)
+		resp, err := client.Delete(ctx, automation.Workflows, "91cc8988-2223-404a-a3f5-5f1a839ecd45")
+		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+		assert.Equal(t, 2, server.Calls())
+		assert.Nil(t, err)
+	})
+
+	t.Run("Delete - adminAccess forbidden - resource not found", func(t *testing.T) {
+		responses := []testutils.ServerResponses{{
+			http.MethodDelete: {
+				ResponseCode: http.StatusNotFound,
+				ResponseBody: "{}",
+			},
+		}}
+
+		server := testutils.NewHTTPTestServer(t, responses)
+		defer server.Close()
+
+		client := automation.NewClient(rest.NewClient(server.URL(), server.Client()))
+		ctx := testutils.ContextWithLogger(t)
+		resp, err := client.Delete(ctx, automation.Workflows, "91cc8988-2223-404a-a3f5-5f1a839ecd45")
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+		assert.Equal(t, 1, server.Calls())
+		assert.Nil(t, err)
+	})
+}
+
+func TestAutomationClient_List(t *testing.T) {
+
+	payloadePages := []string{`{ "count": 3,"results":
+			[
+				{"id": "82e7e7a4-dc69-4a7f-b0ad-7123f579ddf6","title": "Workflow1"},
+				{"id": "da105889-3817-435a-8b15-ec9777374b99","title": "Workflow2"}
+  			]
+		}`,
+		`{ "count": 3,"results":
+			[
+				{"id": "82e7e7a4-dc69-4a7f-b0ad-7123f579ddf6","title": "Workflow3"}
+  			]
+		}`,
+	}
+
+	t.Run("List - Paginated - OK", func(t *testing.T) {
+		responses := []testutils.ServerResponses{{
+			http.MethodGet: {
+				ResponseCode: http.StatusOK,
+				ResponseBody: payloadePages[0],
+				ValidateRequestFunc: func(request *http.Request) {
+					assert.Equal(t, []string{"0"}, request.URL.Query()["offset"])
+				},
+			},
+		},
+			{
+				http.MethodGet: {
+					ResponseCode: http.StatusOK,
+					ResponseBody: payloadePages[1],
+					ValidateRequestFunc: func(request *http.Request) {
+						assert.Equal(t, []string{"1"}, request.URL.Query()["offset"])
+					},
+				},
+			},
+		}
+		server := testutils.NewHTTPTestServer(t, responses)
+		defer server.Close()
+
+		client := automation.NewClient(rest.NewClient(server.URL(), server.Client()))
+		ctx := testutils.ContextWithLogger(t)
+		resp, err := client.List(ctx, automation.Workflows)
+		assert.Len(t, resp, 2)
+		assert.Len(t, resp[0].Objects, 2)
+		assert.Len(t, resp[1].Objects, 1)
+		assert.Nil(t, err)
+	})
+
+	t.Run("List - Paginated - Getting one page fails", func(t *testing.T) {
+		responses := []testutils.ServerResponses{{
+			http.MethodGet: {
+				ResponseCode: http.StatusOK,
+				ResponseBody: payloadePages[0],
+				ValidateRequestFunc: func(request *http.Request) {
+					assert.Equal(t, []string{"0"}, request.URL.Query()["offset"])
+				},
+			},
+		},
+			{
+				http.MethodGet: {
+					ResponseCode: http.StatusInternalServerError,
+					ResponseBody: "{}",
+					ValidateRequestFunc: func(request *http.Request) {
+						assert.Equal(t, []string{"1"}, request.URL.Query()["offset"])
+					},
+				},
+			},
+		}
+		server := testutils.NewHTTPTestServer(t, responses)
+		defer server.Close()
+
+		client := automation.NewClient(rest.NewClient(server.URL(), server.Client()))
+		ctx := testutils.ContextWithLogger(t)
+		resp, err := client.List(ctx, automation.Workflows)
+		assert.Len(t, resp, 1)
+		assert.Len(t, resp[0].Objects, 0)
+		assert.Nil(t, err)
+	})
+
+	t.Run("List - API Call returned with != 2xx", func(t *testing.T) {
+		responses := []testutils.ServerResponses{{
+			http.MethodGet: {
+				ResponseCode: http.StatusBadRequest,
+				ResponseBody: "{}",
+			},
+		},
+		}
+		server := testutils.NewHTTPTestServer(t, responses)
+		defer server.Close()
+
+		client := automation.NewClient(rest.NewClient(server.URL(), server.Client()))
+		ctx := testutils.ContextWithLogger(t)
+		resp, err := client.List(ctx, automation.Workflows)
+		assert.Len(t, resp, 1)
+		assert.Equal(t, resp[0].Response.StatusCode, http.StatusBadRequest)
+		assert.Len(t, resp[0].Objects, 0)
+		assert.Nil(t, err)
+	})
+
+	t.Run("List - API Call failed", func(t *testing.T) {
+		responses := []testutils.ServerResponses{{
+			http.MethodGet: {},
+		},
+		}
+		server := testutils.NewHTTPTestServer(t, responses)
+		defer server.Close()
+
+		client := automation.NewClient(rest.NewClient(server.URL(), server.FaultyClient()))
+		ctx := testutils.ContextWithLogger(t)
+		resp, err := client.List(ctx, automation.Workflows)
+		assert.Equal(t, automation.PagedListResponse{}, resp)
+		assert.NotNil(t, err)
+	})
+}
+
+func TestPagedListResponse(t *testing.T) {
+	pr := automation.PagedListResponse{
+		automation.ListResponse{
+			api.ListResponse{
+				Response: api.Response{},
+				Objects: [][]byte{
+					{'1'},
+					{'2'},
+				},
+			},
+		},
+		automation.ListResponse{
+			api.ListResponse{
+				Response: api.Response{},
+				Objects: [][]byte{
+					{'3'},
+					{'4'},
+				},
+			},
+		},
+	}
+
+	assert.Equal(t, [][]byte{{'1'}, {'2'}, {'3'}, {'4'}}, pr.Objects())
+}

--- a/api/clients/automation/automation_test.go
+++ b/api/clients/automation/automation_test.go
@@ -509,32 +509,28 @@ func TestAutomationClient_List(t *testing.T) {
 		client := automation.NewClient(rest.NewClient(server.URL(), server.FaultyClient()))
 		ctx := testutils.ContextWithLogger(t)
 		resp, err := client.List(ctx, automation.Workflows)
-		assert.Equal(t, automation.PagedListResponse{}, resp)
+		assert.Equal(t, api.PagedListResponse{}, resp)
 		assert.NotNil(t, err)
 	})
 }
 
 func TestPagedListResponse(t *testing.T) {
-	pr := automation.PagedListResponse{
-		automation.ListResponse{
-			api.ListResponse{
-				Response: api.Response{},
-				Objects: [][]byte{
-					{'1'},
-					{'2'},
-				},
+	pr := api.PagedListResponse{
+		api.ListResponse{
+			Response: api.Response{},
+			Objects: [][]byte{
+				{'1'},
+				{'2'},
 			},
 		},
-		automation.ListResponse{
-			api.ListResponse{
-				Response: api.Response{},
-				Objects: [][]byte{
-					{'3'},
-					{'4'},
-				},
+		api.ListResponse{
+			Response: api.Response{},
+			Objects: [][]byte{
+				{'3'},
+				{'4'},
 			},
 		},
 	}
 
-	assert.Equal(t, [][]byte{{'1'}, {'2'}, {'3'}, {'4'}}, pr.Objects())
+	assert.Equal(t, [][]byte{{'1'}, {'2'}, {'3'}, {'4'}}, pr.All())
 }

--- a/api/clients/buckets/bucket_test.go
+++ b/api/clients/buckets/bucket_test.go
@@ -42,12 +42,12 @@ func TestGet(t *testing.T) {
  "version": 1
 }`
 
-		responses := testutils.ServerResponses{
+		responses := []testutils.ServerResponses{{
 			http.MethodGet: {
 				ResponseCode: http.StatusOK,
 				ResponseBody: payload,
 			},
-		}
+		}}
 		server := testutils.NewHTTPTestServer(t, responses)
 		defer server.Close()
 
@@ -61,12 +61,12 @@ func TestGet(t *testing.T) {
 	})
 
 	t.Run("correctly create the error in case of a server issue", func(t *testing.T) {
-		responses := testutils.ServerResponses{
+		responses := []testutils.ServerResponses{{
 			http.MethodGet: {
 				ResponseCode: http.StatusNotFound,
 				ResponseBody: "{}",
 			},
-		}
+		}}
 		server := testutils.NewHTTPTestServer(t, responses)
 		defer server.Close()
 
@@ -107,12 +107,12 @@ func TestList(t *testing.T) {
 	]
 }`, bucket1, bucket2)
 
-		responses := testutils.ServerResponses{
+		responses := []testutils.ServerResponses{{
 			http.MethodGet: {
 				ResponseCode: http.StatusOK,
 				ResponseBody: payload,
 			},
-		}
+		}}
 		server := testutils.NewHTTPTestServer(t, responses)
 		defer server.Close()
 
@@ -128,12 +128,12 @@ func TestList(t *testing.T) {
 
 	t.Run("successfully returns empty response if no buckets exist", func(t *testing.T) {
 		const payload = `{ "buckets": [] }`
-		responses := testutils.ServerResponses{
+		responses := []testutils.ServerResponses{{
 			http.MethodGet: {
 				ResponseCode: http.StatusOK,
 				ResponseBody: payload,
 			},
-		}
+		}}
 		server := testutils.NewHTTPTestServer(t, responses)
 		defer server.Close()
 
@@ -148,12 +148,12 @@ func TestList(t *testing.T) {
 	})
 
 	t.Run("successfully returns response in case of HTTP error", func(t *testing.T) {
-		responses := testutils.ServerResponses{
+		responses := []testutils.ServerResponses{{
 			http.MethodGet: {
 				ResponseCode: http.StatusNotFound,
 				ResponseBody: "{}",
 			},
-		}
+		}}
 		server := testutils.NewHTTPTestServer(t, responses)
 		defer server.Close()
 
@@ -206,7 +206,7 @@ func TestUpsert(t *testing.T) {
 }`
 
 	t.Run("create new bucket - OK", func(t *testing.T) {
-		responses := testutils.ServerResponses{
+		responses := []testutils.ServerResponses{{
 			http.MethodPost: {
 				ResponseCode: http.StatusOK,
 				ResponseBody: creatingBucketResponse,
@@ -225,7 +225,7 @@ func TestUpsert(t *testing.T) {
 				ResponseCode: http.StatusOK,
 				ResponseBody: activeBucketResponse,
 			},
-		}
+		}}
 		server := testutils.NewHTTPTestServer(t, responses)
 		defer server.Close()
 
@@ -281,7 +281,7 @@ func TestUpsert(t *testing.T) {
 	})
 
 	t.Run("create fails", func(t *testing.T) {
-		responses := testutils.ServerResponses{
+		responses := []testutils.ServerResponses{{
 			http.MethodPost: {
 				ResponseCode: http.StatusForbidden,
 				ResponseBody: "Bucket exists",
@@ -294,7 +294,7 @@ func TestUpsert(t *testing.T) {
 				ResponseCode: http.StatusOK,
 				ResponseBody: activeBucketResponse,
 			},
-		}
+		}}
 		server := testutils.NewHTTPTestServer(t, responses)
 		defer server.Close()
 
@@ -309,7 +309,7 @@ func TestUpsert(t *testing.T) {
 	})
 
 	t.Run("bucket exists, update - OK", func(t *testing.T) {
-		responses := testutils.ServerResponses{
+		responses := []testutils.ServerResponses{{
 			http.MethodPost: {
 				ResponseCode: http.StatusConflict,
 				ResponseBody: "Bucket exists",
@@ -335,7 +335,7 @@ func TestUpsert(t *testing.T) {
 					assert.Equal(t, "bucket name", m["bucketName"])
 				},
 			},
-		}
+		}}
 		server := testutils.NewHTTPTestServer(t, responses)
 		defer server.Close()
 
@@ -355,7 +355,7 @@ func TestUpsert(t *testing.T) {
 	})
 
 	t.Run("bucket exists, update fails", func(t *testing.T) {
-		responses := testutils.ServerResponses{
+		responses := []testutils.ServerResponses{{
 			http.MethodPost: {
 				ResponseCode: http.StatusConflict,
 				ResponseBody: "Bucket exists",
@@ -368,7 +368,7 @@ func TestUpsert(t *testing.T) {
 				ResponseCode: http.StatusForbidden,
 				ResponseBody: "no write access message",
 			},
-		}
+		}}
 		server := testutils.NewHTTPTestServer(t, responses)
 		defer server.Close()
 
@@ -383,7 +383,7 @@ func TestUpsert(t *testing.T) {
 	})
 
 	t.Run("bucket exists, update fails with conflict", func(t *testing.T) {
-		responses := testutils.ServerResponses{
+		responses := []testutils.ServerResponses{{
 			http.MethodPost: {
 				ResponseCode: http.StatusConflict,
 				ResponseBody: "Bucket exists",
@@ -396,7 +396,7 @@ func TestUpsert(t *testing.T) {
 				ResponseCode: http.StatusConflict,
 				ResponseBody: `some conflicting error'`,
 			},
-		}
+		}}
 		server := testutils.NewHTTPTestServer(t, responses)
 		defer server.Close()
 
@@ -413,7 +413,7 @@ func TestUpsert(t *testing.T) {
 	})
 
 	t.Run("bucket exists, update fails because GET fails", func(t *testing.T) {
-		responses := testutils.ServerResponses{
+		responses := []testutils.ServerResponses{{
 			http.MethodPost: {
 				ResponseCode: http.StatusConflict,
 				ResponseBody: "expected error, we don't want to create",
@@ -422,7 +422,7 @@ func TestUpsert(t *testing.T) {
 				ResponseCode: http.StatusNotFound,
 				ResponseBody: "expected error, we don't want to get",
 			},
-		}
+		}}
 		server := testutils.NewHTTPTestServer(t, responses)
 		defer server.Close()
 
@@ -480,7 +480,7 @@ func TestUpsert(t *testing.T) {
 	})
 
 	t.Run("bucket exists, but is not modified, no update happens", func(t *testing.T) {
-		responses := testutils.ServerResponses{
+		responses := []testutils.ServerResponses{{
 			http.MethodPost: {
 				ResponseCode: http.StatusConflict,
 				ResponseBody: "Bucket exists",
@@ -492,7 +492,7 @@ func TestUpsert(t *testing.T) {
 					assert.Contains(t, req.URL.String(), url.PathEscape("bucket name"))
 				},
 			},
-		}
+		}}
 		server := testutils.NewHTTPTestServer(t, responses)
 		defer server.Close()
 
@@ -520,12 +520,12 @@ func TestDelete(t *testing.T) {
 }`
 
 	t.Run("delete bucket - OK", func(t *testing.T) {
-		responses := testutils.ServerResponses{
+		responses := []testutils.ServerResponses{{
 			http.MethodDelete: {
 				ResponseCode: http.StatusAccepted,
 				ResponseBody: someBucketResponse,
 			},
-		}
+		}}
 		server := testutils.NewHTTPTestServer(t, responses)
 		defer server.Close()
 
@@ -540,11 +540,11 @@ func TestDelete(t *testing.T) {
 	})
 
 	t.Run("delete bucket - not found", func(t *testing.T) {
-		responses := testutils.ServerResponses{
+		responses := []testutils.ServerResponses{{
 			http.MethodDelete: {
 				ResponseCode: http.StatusNotFound,
 			},
-		}
+		}}
 		server := testutils.NewHTTPTestServer(t, responses)
 		defer server.Close()
 
@@ -559,11 +559,11 @@ func TestDelete(t *testing.T) {
 	})
 
 	t.Run("delete bucket - network error", func(t *testing.T) {
-		responses := testutils.ServerResponses{
+		responses := []testutils.ServerResponses{{
 			http.MethodDelete: {
 				ResponseCode: http.StatusNotFound,
 			},
-		}
+		}}
 		server := testutils.NewHTTPTestServer(t, responses)
 		defer server.Close()
 
@@ -608,7 +608,7 @@ func TestCreate(t *testing.T) {
 }`
 
 	t.Run("create bucket - OK", func(t *testing.T) {
-		responses := testutils.ServerResponses{
+		responses := []testutils.ServerResponses{{
 			http.MethodPost: {
 				ResponseCode: http.StatusCreated,
 				ResponseBody: creatingBucketResponse,
@@ -617,7 +617,7 @@ func TestCreate(t *testing.T) {
 				ResponseCode: http.StatusOK,
 				ResponseBody: activeBucketResponse,
 			},
-		}
+		}}
 		server := testutils.NewHTTPTestServer(t, responses)
 		defer server.Close()
 
@@ -668,9 +668,9 @@ func TestCreate(t *testing.T) {
 	})
 
 	t.Run("create bucket - network error", func(t *testing.T) {
-		responses := testutils.ServerResponses{
+		responses := []testutils.ServerResponses{{
 			// no request should reach test server
-		}
+		}}
 		server := testutils.NewHTTPTestServer(t, responses)
 		defer server.Close()
 
@@ -684,9 +684,9 @@ func TestCreate(t *testing.T) {
 	})
 
 	t.Run("create bucket - invalid data", func(t *testing.T) {
-		responses := testutils.ServerResponses{
+		responses := []testutils.ServerResponses{{
 			// no request should reach test server
-		}
+		}}
 		server := testutils.NewHTTPTestServer(t, responses)
 		defer server.Close()
 
@@ -712,7 +712,7 @@ func TestUpdate(t *testing.T) {
   "version": 1
 }`
 	t.Run("update fails", func(t *testing.T) {
-		responses := testutils.ServerResponses{
+		responses := []testutils.ServerResponses{{
 			http.MethodGet: {
 				ResponseCode: http.StatusOK,
 				ResponseBody: someBucketResponse,
@@ -721,7 +721,7 @@ func TestUpdate(t *testing.T) {
 				ResponseCode: http.StatusForbidden,
 				ResponseBody: "no write access message",
 			},
-		}
+		}}
 		server := testutils.NewHTTPTestServer(t, responses)
 		defer server.Close()
 
@@ -735,7 +735,7 @@ func TestUpdate(t *testing.T) {
 	})
 
 	t.Run("update bucket - OK", func(t *testing.T) {
-		responses := testutils.ServerResponses{
+		responses := []testutils.ServerResponses{{
 			http.MethodGet: {
 				ResponseCode: http.StatusOK,
 				ResponseBody: someBucketResponse,
@@ -757,7 +757,7 @@ func TestUpdate(t *testing.T) {
 					assert.Equal(t, "bucket name", m["bucketName"])
 				},
 			},
-		}
+		}}
 		server := testutils.NewHTTPTestServer(t, responses)
 		defer server.Close()
 
@@ -776,7 +776,7 @@ func TestUpdate(t *testing.T) {
 	})
 
 	t.Run("unmodified bucket - nothing happens", func(t *testing.T) {
-		responses := testutils.ServerResponses{
+		responses := []testutils.ServerResponses{{
 			http.MethodGet: {
 				ResponseCode: http.StatusOK,
 				ResponseBody: someBucketResponse,
@@ -784,7 +784,7 @@ func TestUpdate(t *testing.T) {
 					assert.Contains(t, req.URL.String(), url.PathEscape("bucket name"))
 				},
 			},
-		}
+		}}
 		server := testutils.NewHTTPTestServer(t, responses)
 		defer server.Close()
 
@@ -805,7 +805,7 @@ func TestUpdate(t *testing.T) {
 	})
 
 	t.Run("Update fails with conflict", func(t *testing.T) {
-		responses := testutils.ServerResponses{
+		responses := []testutils.ServerResponses{{
 			http.MethodGet: {
 				ResponseCode: http.StatusOK,
 				ResponseBody: someBucketResponse,
@@ -814,7 +814,7 @@ func TestUpdate(t *testing.T) {
 				ResponseCode: http.StatusConflict,
 				ResponseBody: `some conflicting error'`,
 			},
-		}
+		}}
 		server := testutils.NewHTTPTestServer(t, responses)
 		defer server.Close()
 
@@ -830,7 +830,7 @@ func TestUpdate(t *testing.T) {
 	})
 
 	t.Run("Update fails because GET fails", func(t *testing.T) {
-		responses := testutils.ServerResponses{
+		responses := []testutils.ServerResponses{{
 			http.MethodPost: {
 				ResponseCode: http.StatusForbidden,
 				ResponseBody: "expected error, we don't want to create",
@@ -839,7 +839,7 @@ func TestUpdate(t *testing.T) {
 				ResponseCode: http.StatusForbidden,
 				ResponseBody: "expected error, we don't want to get",
 			},
-		}
+		}}
 		server := testutils.NewHTTPTestServer(t, responses)
 		defer server.Close()
 
@@ -956,12 +956,12 @@ func TestDecodingBucketResponses(t *testing.T) {
 	}
 
 	t.Run("Get single bucket", func(t *testing.T) {
-		responses := testutils.ServerResponses{
+		responses := []testutils.ServerResponses{{
 			http.MethodGet: {
 				ResponseCode: http.StatusOK,
 				ResponseBody: bucket1,
 			},
-		}
+		}}
 		server := testutils.NewHTTPTestServer(t, responses)
 		defer server.Close()
 
@@ -988,12 +988,12 @@ func TestDecodingBucketResponses(t *testing.T) {
 	]
 }`, bucket1, bucket2)
 
-		responses := testutils.ServerResponses{
+		responses := []testutils.ServerResponses{{
 			http.MethodGet: {
 				ResponseCode: http.StatusOK,
 				ResponseBody: payload,
 			},
-		}
+		}}
 		server := testutils.NewHTTPTestServer(t, responses)
 		defer server.Close()
 

--- a/api/clients/factory.go
+++ b/api/clients/factory.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/auth"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/clients/automation"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/clients/buckets"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
 	"net/url"
@@ -70,8 +71,25 @@ func (f factory) WithHTTPListener(listener *rest.HTTPListener) factory {
 	return f
 }
 
+// AutomationClient creates and returns a new instance of automation.Client for interacting with the automation API.
+func (f factory) AutomationClient() (*automation.Client, error) {
+	restClient, err := f.createClient()
+	if err != nil {
+		return nil, err
+	}
+	return automation.NewClient(restClient), nil
+}
+
 // BucketClient creates and returns a new instance of buckets.Client for interacting with the bucket API.
 func (f factory) BucketClient() (*buckets.Client, error) {
+	restClient, err := f.createClient()
+	if err != nil {
+		return nil, err
+	}
+	return buckets.NewClient(restClient), nil
+}
+
+func (f factory) createClient() (*rest.Client, error) {
 	if f.url == "" {
 		return nil, ErrEnvironmentURLMissing
 	}
@@ -90,5 +108,5 @@ func (f factory) BucketClient() (*buckets.Client, error) {
 		restClient.SetHeader("User-Agent", f.userAgent)
 	}
 
-	return buckets.NewClient(restClient), nil
+	return restClient, nil
 }

--- a/api/clients/factory_test.go
+++ b/api/clients/factory_test.go
@@ -15,6 +15,8 @@
 package clients
 
 import (
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/clients/automation"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/clients/buckets"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/oauth2/clientcredentials"
 	"testing"
@@ -32,9 +34,17 @@ func TestClientCreation(t *testing.T) {
 		}).
 		WithUserAgent("MyUserAgent")
 
-	client, err := f.BucketClient()
+	var clientInstance interface{}
+	clientInstance, err := f.BucketClient()
 	assert.NoError(t, err)
-	assert.NotNil(t, client)
+	assert.NotNil(t, clientInstance)
+	assert.IsType(t, &buckets.Client{}, clientInstance)
+
+	clientInstance, err = f.AutomationClient()
+	assert.NoError(t, err)
+	assert.NotNil(t, clientInstance)
+	assert.IsType(t, &automation.Client{}, clientInstance)
+
 	//... other clients
 }
 
@@ -49,10 +59,17 @@ func TestClientMissingEnvironmentURL(t *testing.T) {
 		}).
 		WithUserAgent("MyUserAgent")
 
-	client, err := f.BucketClient()
+	var clientInstance interface{}
+	clientInstance, err := f.BucketClient()
 	assert.Error(t, err)
-	assert.Nil(t, client)
+	assert.Nil(t, clientInstance)
 	assert.ErrorIs(t, err, ErrEnvironmentURLMissing)
+
+	clientInstance, err = f.AutomationClient()
+	assert.Error(t, err)
+	assert.Nil(t, clientInstance)
+	assert.ErrorIs(t, err, ErrEnvironmentURLMissing)
+
 	//... other clients
 }
 
@@ -63,10 +80,17 @@ func TestClientMissingOAuthCredentials(t *testing.T) {
 		WithEnvironmentURL("https://example.com/api").
 		WithUserAgent("MyUserAgent")
 
-	client, err := f.BucketClient()
+	var clientInstance interface{}
+	clientInstance, err := f.BucketClient()
 	assert.Error(t, err)
-	assert.Nil(t, client)
+	assert.Nil(t, clientInstance)
 	assert.ErrorIs(t, err, ErrOAuthCredentialsMissing)
+
+	clientInstance, err = f.AutomationClient()
+	assert.Error(t, err)
+	assert.Nil(t, clientInstance)
+	assert.ErrorIs(t, err, ErrOAuthCredentialsMissing)
+
 	//... other clients
 }
 
@@ -82,9 +106,16 @@ func TestClientURLParsingError(t *testing.T) {
 		}).
 		WithUserAgent("MyUserAgent")
 
-	client, err := f.BucketClient()
+	var clientInstance interface{}
+	clientInstance, err := f.BucketClient()
 	assert.Error(t, err)
-	assert.Nil(t, client)
+	assert.Nil(t, clientInstance)
 	assert.ErrorContains(t, err, "failed to parse URL")
+
+	clientInstance, err = f.AutomationClient()
+	assert.Error(t, err)
+	assert.Nil(t, clientInstance)
+	assert.ErrorContains(t, err, "failed to parse URL")
+
 	//... other clients
 }

--- a/api/response.go
+++ b/api/response.go
@@ -27,6 +27,23 @@ type Response struct {
 	Request    rest.RequestInfo `json:"-"`
 }
 
+// PagedListResponse is a list of ListResponse values.
+// It is used by return values of APIs that support pagination.
+// Each ListResponse entry possibly contains multiple objects of the fetched resource type.
+// To get all response objects in a single slice you can call All()
+type PagedListResponse []ListResponse
+
+// All returns all objects of a PagedListResponse in one slice
+func (p PagedListResponse) All() [][]byte {
+	var ret [][]byte
+	for _, l := range []ListResponse(p) {
+		for _, o := range l.Objects {
+			ret = append(ret, o)
+		}
+	}
+	return ret
+}
+
 // ListResponse represents a multi-object API response
 // It contains both the full JSON Data, and a slice of Objects for more convenient access
 type ListResponse struct {
@@ -97,7 +114,7 @@ func DecodeJSON[T any](r Response) (T, error) {
 	return t, nil
 }
 
-// DecodeJSONObjects unmarshalls the Objects contained in the given ListResponse into a slice of T.
+// DecodeJSONObjects unmarshalls Objects contained in the given ListResponse into a slice of T.
 // To decode the full JSON response contained in ListResponse use Response.DecodeJSON.
 func DecodeJSONObjects[T any](r ListResponse) ([]T, error) {
 	res := make([]T, len(r.Objects))

--- a/api/response_test.go
+++ b/api/response_test.go
@@ -163,3 +163,24 @@ func TestAsAPIError(t *testing.T) {
 		})
 	}
 }
+
+func TestPagedListResponse(t *testing.T) {
+	pr := PagedListResponse{
+		ListResponse{
+			Response: Response{},
+			Objects: [][]byte{
+				{'1'},
+				{'2'},
+			},
+		},
+		ListResponse{
+			Response: Response{},
+			Objects: [][]byte{
+				{'3'},
+				{'4'},
+			},
+		},
+	}
+
+	assert.Equal(t, [][]byte{{'1'}, {'2'}, {'3'}, {'4'}}, pr.All())
+}

--- a/api/rest/client.go
+++ b/api/rest/client.go
@@ -134,6 +134,11 @@ func (c *Client) SetHeader(key, value string) {
 	c.headers[key] = value
 }
 
+// BaseURL returns the base url configured fpr this client
+func (c *Client) BaseURL() *url.URL {
+	return c.baseURL
+}
+
 // sendRequestWithRetries sends an HTTP request with custom headers and modified request body, with retries if configured.
 func (c *Client) sendRequestWithRetries(ctx context.Context, method string, endpoint string, body io.Reader, retryCount int, options RequestOptions) (Response, error) {
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code-core/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of the current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
This PR introduces a new client targeting the automation API. It provides support for workflows, business-calendars, and scheduling rules.

The client can be obtained via the factory as usual and offers CRUD + Upsert operations.
#### Special notes for your reviewer:
I have not yet added logging to the client.
This is planned for a follow-up PR to solely focus on useful logs.
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
Yes, user has access to new automation client, e.g. via the existing factory:

```go
client, err := factory.AutomationClient()
if err != nil {
   // handle err
}
```

from here on you can call the desired operation on the client, e.g. getting an existing workflow:
```go
response, err = automationClient.Get(context.TODO(), automation.Workflows, id)
if err != nil {
	panic(err)
}

if err, isAPIErr := response.AsAPIError(); isAPIErr {
	panic(err)
}
....
```

