### PR TITLE
refactor: unify return types of clients

### DIFF
--- a/api/clients/buckets/bucket.go
+++ b/api/clients/buckets/bucket.go
@@ -43,9 +43,7 @@ type Response = api.Response
 
 // ListResponse is a Bucket API response containing multiple bucket objects.
 // For convenience, it contains a slice of Buckets in addition to the base api.Response data.
-type ListResponse struct {
-	api.ListResponse
-}
+type ListResponse = api.PagedListResponse
 
 type listResponse struct {
 	api.Response
@@ -160,7 +158,7 @@ func (c Client) List(ctx context.Context) (ListResponse, error) {
 	}
 
 	return ListResponse{
-		ListResponse: api.ListResponse{
+		api.ListResponse{
 			Response: resp.Response,
 			Objects:  b,
 		},

--- a/api/clients/buckets/bucket.go
+++ b/api/clients/buckets/bucket.go
@@ -32,16 +32,14 @@ import (
 
 const endpointPath = "platform/storage/management/v1/bucket-definitions"
 
-type Response struct {
-	api.Response
-}
-
 type response struct {
 	api.Response
 	BucketName string `json:"bucketName"`
 	Status     string `json:"status"`
 	Version    int    `json:"version"`
 }
+
+type Response = api.Response
 
 // ListResponse is a Bucket API response containing multiple bucket objects.
 // For convenience, it contains a slice of Buckets in addition to the base api.Response data.
@@ -131,9 +129,9 @@ func NewClient(client *rest.Client, option ...Option) *Client {
 func (c Client) Get(ctx context.Context, bucketName string) (Response, error) {
 	resp, err := c.get(ctx, bucketName)
 	if err != nil {
-		return Response{}, err
+		return api.Response{}, err
 	}
-	return Response{api.Response{StatusCode: resp.StatusCode, Data: resp.Payload, Request: resp.RequestInfo}}, nil
+	return api.Response{StatusCode: resp.StatusCode, Data: resp.Payload, Request: resp.RequestInfo}, nil
 }
 
 // List retrieves all bucket definitions. The function sends a GET request
@@ -189,14 +187,12 @@ func (c Client) List(ctx context.Context) (ListResponse, error) {
 func (c Client) Create(ctx context.Context, bucketName string, data []byte) (Response, error) {
 	resp, err := c.create(ctx, bucketName, data)
 	if err != nil {
-		return Response{}, err
+		return api.Response{}, err
 	}
-	return Response{
-		Response: api.Response{
-			StatusCode: resp.StatusCode,
-			Data:       resp.Payload,
-			Request:    resp.RequestInfo,
-		},
+	return api.Response{
+		StatusCode: resp.StatusCode,
+		Data:       resp.Payload,
+		Request:    resp.RequestInfo,
 	}, nil
 }
 
@@ -231,14 +227,14 @@ func (c Client) Update(ctx context.Context, bucketName string, data []byte) (Res
 	// check if bucket needs to be updated at all
 	resp, err := c.get(ctx, bucketName)
 	if err != nil {
-		return Response{}, err
+		return api.Response{}, err
 	}
 	if bucketsEqual(resp.Payload, data) {
 		logger.Info(fmt.Sprintf("Configuration unmodified, no need to update bucket with bucket name %q", bucketName))
 
-		return Response{api.Response{
+		return api.Response{
 			StatusCode: 200,
-		}}, nil
+		}, nil
 	}
 
 	// attempt update
@@ -247,36 +243,34 @@ func (c Client) Update(ctx context.Context, bucketName string, data []byte) (Res
 	for i := 0; i < c.retrySettings.maxRetries; i++ {
 		select {
 		case <-ctx.Done():
-			return Response{}, fmt.Errorf("context canceled before bucket with bucktName %q became available", bucketName)
+			return api.Response{}, fmt.Errorf("context canceled before bucket with bucktName %q became available", bucketName)
 		default:
 			logger.V(1).Info(fmt.Sprintf("Trying to update bucket with bucket name %q (%d/%d retries)", bucketName, i+1, c.retrySettings.maxRetries))
 
 			resp, err = c.getAndUpdate(ctx, bucketName, data)
 			if err != nil {
-				return Response{}, err
+				return api.Response{}, err
 			}
 
 			if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusBadRequest {
-				return Response{api.Response{
+				return api.Response{
 					StatusCode: resp.StatusCode,
 					Data:       resp.Payload,
 					Request:    resp.RequestInfo,
-				}}, nil
+				}, nil
 			}
 
 			if resp.IsSuccess() {
 				logger.Info(fmt.Sprintf("Updated bucket with bucket name %q", bucketName))
-				return Response{api.Response{StatusCode: resp.StatusCode, Data: resp.Payload, Request: resp.RequestInfo}}, nil
+				return api.Response{StatusCode: resp.StatusCode, Data: resp.Payload, Request: resp.RequestInfo}, nil
 			}
 			time.Sleep(c.retrySettings.durationBetweenTries)
 		}
 	}
-	return Response{
-		Response: api.Response{
-			StatusCode: resp.StatusCode,
-			Data:       resp.Payload,
-			Request:    resp.RequestInfo,
-		},
+	return api.Response{
+		StatusCode: resp.StatusCode,
+		Data:       resp.Payload,
+		Request:    resp.RequestInfo,
 	}, err
 }
 
@@ -301,7 +295,7 @@ func (c Client) Update(ctx context.Context, bucketName string, data []byte) (Res
 //   - error: An error if the HTTP call fails or another error happened.
 func (c Client) Upsert(ctx context.Context, bucketName string, data []byte) (Response, error) {
 	if bucketName == "" {
-		return Response{}, fmt.Errorf("bucketName must be non-empty")
+		return api.Response{}, fmt.Errorf("bucketName must be non-empty")
 	}
 	return c.upsert(ctx, bucketName, data)
 }
@@ -323,17 +317,17 @@ func (c Client) Upsert(ctx context.Context, bucketName string, data []byte) (Res
 //   - error: An error if the HTTP call fails or another error happened.
 func (c Client) Delete(ctx context.Context, bucketName string) (Response, error) {
 	if bucketName == "" {
-		return Response{}, fmt.Errorf("bucketName must be non-empty")
+		return api.Response{}, fmt.Errorf("bucketName must be non-empty")
 	}
 	path, err := url.JoinPath(endpointPath, bucketName)
 	if err != nil {
-		return Response{}, fmt.Errorf("failed to create URL: %w", err)
+		return api.Response{}, fmt.Errorf("failed to create URL: %w", err)
 	}
 	resp, err := c.client.DELETE(ctx, path, rest.RequestOptions{})
 	if err != nil {
-		return Response{}, fmt.Errorf("unable to delete object with bucket name %q: %w", bucketName, err)
+		return api.Response{}, fmt.Errorf("unable to delete object with bucket name %q: %w", bucketName, err)
 	}
-	return Response{api.Response{StatusCode: resp.StatusCode, Data: resp.Payload, Request: resp.RequestInfo}}, err
+	return api.Response{StatusCode: resp.StatusCode, Data: resp.Payload, Request: resp.RequestInfo}, err
 }
 
 // upsert is an internal function used by Upsert to perform the create or update logic.
@@ -344,18 +338,18 @@ func (c Client) upsert(ctx context.Context, bucketName string, data []byte) (Res
 	// First, try to create a new bucket definition
 	resp, err := c.create(ctx, bucketName, data)
 	if err != nil {
-		return Response{}, err
+		return api.Response{}, err
 	}
 
 	// If creating the bucket definition worked, return the result
 	if resp.IsSuccess() {
 		logger.Info(fmt.Sprintf("Created bucket with bucket name %q", bucketName))
-		return Response{api.Response{StatusCode: resp.StatusCode, Data: resp.Payload, Request: resp.RequestInfo}}, nil
+		return api.Response{StatusCode: resp.StatusCode, Data: resp.Payload, Request: resp.RequestInfo}, nil
 	}
 
 	// Return if creation failed, but the errors was not 409 Conflict - Bucket already exists
 	if resp.StatusCode != http.StatusConflict {
-		return Response{api.Response{StatusCode: resp.StatusCode, Data: resp.Payload, Request: resp.RequestInfo}}, err
+		return api.Response{StatusCode: resp.StatusCode, Data: resp.Payload, Request: resp.RequestInfo}, err
 	}
 
 	// Otherwise, try to update an existing bucket definition

--- a/api/clients/buckets/bucket_test.go
+++ b/api/clients/buckets/bucket_test.go
@@ -137,8 +137,8 @@ func TestList(t *testing.T) {
 
 		resp, err := client.List(ctx)
 		assert.NoError(t, err)
-		assert.Equal(t, resp.Data, []byte(payload))
-		assert.ElementsMatch(t, resp.Objects, [][]byte{[]byte(bucket1), []byte(bucket2)})
+		assert.Equal(t, resp[0].Data, []byte(payload))
+		assert.ElementsMatch(t, resp.All(), [][]byte{[]byte(bucket1), []byte(bucket2)})
 	})
 
 	t.Run("successfully returns empty response if no buckets exist", func(t *testing.T) {
@@ -162,8 +162,8 @@ func TestList(t *testing.T) {
 
 		resp, err := client.List(ctx)
 		assert.NoError(t, err, "expected err to be nil")
-		assert.Equal(t, resp.Data, []byte(payload))
-		assert.Empty(t, resp.Objects)
+		assert.Equal(t, resp[0].Data, []byte(payload))
+		assert.Empty(t, resp.All())
 	})
 
 	t.Run("successfully returns response in case of HTTP error", func(t *testing.T) {
@@ -186,7 +186,7 @@ func TestList(t *testing.T) {
 
 		resp, err := client.List(ctx)
 		assert.NoError(t, err, "expected err to be nil")
-		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+		assert.Equal(t, http.StatusNotFound, resp[0].StatusCode)
 	})
 
 	t.Run("returns error in case of network error", func(t *testing.T) {
@@ -1238,7 +1238,7 @@ func TestDecodingBucketResponses(t *testing.T) {
 
 		resp, err := client.List(ctx)
 		assert.NoError(t, err)
-		b, err := api.DecodeJSON[bucket](resp.Response)
+		b, err := api.DecodeJSON[bucket](resp[0].Response)
 		assert.NoError(t, err)
 
 		assert.Equal(t, "bucket name", b.Name)
@@ -1275,7 +1275,7 @@ func TestDecodingBucketResponses(t *testing.T) {
 		resp, err := client.List(ctx)
 		assert.NoError(t, err)
 
-		list, err := api.DecodeJSONObjects[bucket](resp.ListResponse)
+		list, err := api.DecodeJSONObjects[bucket](resp[0])
 		assert.NoError(t, err)
 		assert.Len(t, list, 2)
 		assert.Equal(t, bucket{


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code-core/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
Although achieving uniformity across all clients' interfaces may not be practical, standardizing the return signature can be easily accomplished. This simplifies the usage of the client(s) and enhances convenience.
Moreover, these changes support the flexibility to not break any code once an API suddenly introduces pagination.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
:exclamation: Return types are different, thus clients need to adopt the usage.