### PR TITLE
Revert "Bucket Client: Use `CacheControl` header to turn off caching …

### DIFF
--- a/api/clients/buckets/bucket.go
+++ b/api/clients/buckets/bucket.go
@@ -105,7 +105,7 @@ func NewClient(client *rest.Client, option ...Option) *Client {
 	for _, o := range option {
 		o(c)
 	}
-	client.SetHeader("Cache-Control", "no-cache")
+
 	return c
 }
 


### PR DESCRIPTION
This reverts commit 9cf90c0a6cb4f79af0e255767d5dcf45a349bf75.
didn't have the desired effect.
