### PR TITLE
chore: Update go version to 1.22.0

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -36,7 +36,7 @@ jobs:
       - name: 🛠️ Set up Go 1.x
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 #v5.0.0
         with:
-          go-version: '~1.20'
+          go-version: '~1.22'
 
       - name: ⬇️ Check out code into the Go module directory
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1

--- a/.github/workflows/dependencies-and-licenses.yml
+++ b/.github/workflows/dependencies-and-licenses.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 #v5.0.0
         with:
-          go-version: '~1.20'
+          go-version: '~1.22'
       - name: Install go-licence-detector
         run: |
           go install go.elastic.co/go-licence-detector@v0.6.0

--- a/.github/workflows/pr-static-code-analysis.yml
+++ b/.github/workflows/pr-static-code-analysis.yml
@@ -20,7 +20,7 @@ jobs:
       - name: 🛠️ Set up Go 1.x
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 #v5.0.0
         with:
-          go-version: '~1.20'
+          go-version: '~1.22'
 
       - name: ⬇️ Check out code into the Go module directory
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-go 1.20
+go 1.22
 
 module github.com/dynatrace/dynatrace-configuration-as-code-core
 


### PR DESCRIPTION
#### What this PR does / Why we need it:
Updates go.mod and Workflows to use go 1.22 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
