### PR TITLE
feat: document client

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,7 @@ The library provides different kinds of clients to interact with Dynatrace in tw
   However, the specific interface might differ between clients.
   * Payloads to and from the APIs aren't interpreted in any particular way.
   Thus, it's the user's responsibility to marshal/unmarshal payloads into/from Go structs.
-  * API clients typically return `(Response, error)` pairs. Note that any API result (including `4xx`,`5xx`...) will be carried back
-  in the `Response` return value.
-  It is the responsibility of the user to check for success or failure of the actual operations by inspecting the 
-  `Response`. The user can expect `error` to be `!= nil` only for (technical) failures that
-  happen either prior to making the actual HTTP calls or if the HTTP calls couldn't be carried out (e.g. due to network problems, etc.)
+
 
   | API Client          | Implemented |
   |---------------------|-------------|

--- a/api/clients/documents/documents.go
+++ b/api/clients/documents/documents.go
@@ -1,0 +1,117 @@
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package documents
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
+	"net/http"
+	"net/url"
+)
+
+const documentResourcePath = "/platform/document/v1/documents"
+
+type Client struct {
+	client *rest.Client
+}
+
+func NewClient(client *rest.Client) *Client {
+	c := &Client{
+		client: client,
+	}
+	return c
+}
+
+func (c Client) Get(ctx context.Context, id string) (*http.Response, error) {
+	if id == "" {
+		return nil, fmt.Errorf("id must be non empty")
+	}
+
+	path, err := url.JoinPath(documentResourcePath, id)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create URL: %w", err)
+	}
+
+	resp, err := c.client.GET(ctx, path, rest.RequestOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("unable to get object with ID %s: %w", id, err)
+	}
+
+	return resp, err
+}
+
+func (c Client) Create(ctx context.Context, data []byte, requestOptions rest.RequestOptions) (*http.Response, error) {
+	path := documentResourcePath
+
+	resp, err := c.client.POST(ctx, path, bytes.NewReader(data), requestOptions)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create object: %w", err)
+	}
+	return resp, err
+}
+
+func (c Client) List(ctx context.Context, requestOptions rest.RequestOptions) (*http.Response, error) {
+	path := documentResourcePath
+	resp, err := c.client.GET(ctx, path, requestOptions)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get objects: %w", err)
+	}
+
+	return resp, err
+}
+
+func (c Client) Update(ctx context.Context, id string, data []byte, requestOptions rest.RequestOptions) (*http.Response, error) { //nolint:dupl
+	path, err := url.JoinPath(documentResourcePath, id)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create URL: %w", err)
+	}
+
+	resp, err := c.client.PUT(ctx, path, bytes.NewReader(data), requestOptions)
+	if err != nil {
+		return nil, fmt.Errorf("unable to update object: %w", err)
+	}
+	return resp, err
+}
+
+func (c Client) Patch(ctx context.Context, id string, data []byte, requestOptions rest.RequestOptions) (*http.Response, error) { //nolint:dupl
+	path, err := url.JoinPath(documentResourcePath, id)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create URL: %w", err)
+	}
+
+	resp, err := c.client.PATCH(ctx, path, bytes.NewReader(data), requestOptions)
+	if err != nil {
+		return nil, fmt.Errorf("unable to update object: %w", err)
+	}
+	return resp, err
+}
+
+func (c Client) Delete(ctx context.Context, id string, requestOptions rest.RequestOptions) (*http.Response, error) {
+	path, err := url.JoinPath(documentResourcePath, id)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create URL: %w", err)
+	}
+
+	resp, err := c.client.DELETE(ctx, path, requestOptions)
+	if err != nil {
+		return nil, fmt.Errorf("unable to delete object: %w", err)
+	}
+	return resp, err
+
+}

--- a/api/rest/client_test.go
+++ b/api/rest/client_test.go
@@ -662,7 +662,7 @@ func TestClient_WithRetriesAndRateLimit(t *testing.T) {
 
 	ctx := testutils.ContextWithVerboseLogger(t)
 
-	resp, err := client.GET(ctx, "/sample/endpoint", RequestOptions{url.Values{"type": {"car", "bike"}}})
+	resp, err := client.GET(ctx, "/sample/endpoint", RequestOptions{QueryParams: url.Values{"type": {"car", "bike"}}})
 
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
@@ -686,5 +686,5 @@ func TestClient_RequestOptionsQueryParams(t *testing.T) {
 
 	ctx := testutils.ContextWithLogger(t)
 
-	client.GET(ctx, "", RequestOptions{expectedQueryParams})
+	client.GET(ctx, "", RequestOptions{QueryParams: expectedQueryParams})
 }

--- a/clients/documents/documents.go
+++ b/clients/documents/documents.go
@@ -1,0 +1,421 @@
+package documents
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/clients/documents"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+/*
+ * @license
+ * Copyright 2023 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+type DocumentType int
+
+const optimisticLockingHeader = "optimistic-locking-version"
+
+const (
+	Dashboard DocumentType = iota
+	Notebook
+)
+
+var documentTypesValues = map[DocumentType]string{
+	Dashboard: "dashboard",
+	Notebook:  "notebook",
+}
+
+// Client is the HTTP client to be used for interacting with the Document API
+type Client struct {
+	client *documents.Client
+}
+
+// Response contains the API response
+type Response struct {
+	api.Response
+
+	// Metadata fields
+	ID         string `json:"id"`
+	ExternalID string `json:"externalId"`
+	Actor      string `json:"actor"`
+	Owner      string `json:"owner"`
+	Name       string `json:"name"`
+	Type       string `json:"type"`
+	Version    int    `json:"version"`
+}
+
+// ListResponse is a list of API Responses
+type ListResponse struct {
+	api.Response
+	Responses []Response
+}
+
+// NewClient creates a new document client
+func NewClient(client *rest.Client) *Client {
+	c := &Client{client: documents.NewClient(client)}
+	return c
+}
+
+func (c Client) Get(ctx context.Context, id string) (Response, error) {
+	var r Response
+
+	httpResp, err := c.client.Get(ctx, id)
+	if err != nil {
+		return Response{}, fmt.Errorf("failed to get document resource with id %s: %w", id, err)
+	}
+
+	body, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return Response{}, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if err = httpResp.Body.Close(); err != nil {
+		return Response{}, err
+	}
+
+	r.Request = rest.RequestInfo{Method: httpResp.Request.Method, URL: httpResp.Request.URL.String()}
+	r.StatusCode = httpResp.StatusCode
+	r.Data = body
+
+	if !rest.IsSuccess(httpResp) {
+		return r, nil
+	}
+	contentType := httpResp.Header["Content-Type"][0]
+	boundaryIndex := strings.Index(contentType, "boundary=")
+	if boundaryIndex == -1 {
+		return r, fmt.Errorf("no boundary parameter found in Content-Type header")
+	}
+	boundary := contentType[boundaryIndex+len("boundary="):]
+
+	reader := multipart.NewReader(httpResp.Body, boundary)
+
+	form, err := reader.ReadForm(0)
+	if err != nil {
+		return r, fmt.Errorf("unable to read multipart form: %w", err)
+	}
+
+	if len(form.Value["metadata"]) == 0 {
+		return r, fmt.Errorf("metadata field not found in response")
+	}
+
+	err = json.Unmarshal([]byte(form.Value["metadata"][0]), &r)
+	if err != nil {
+		return r, fmt.Errorf("unable to unmarshal metadata: %w", err)
+	}
+
+	file, err := form.File["content"][0].Open()
+	if err != nil {
+		return r, fmt.Errorf("unable to open file: %w", err)
+	}
+	defer file.Close()
+
+	fileContent := new(bytes.Buffer)
+	_, err = fileContent.ReadFrom(file)
+	if err != nil {
+		return r, fmt.Errorf("unable to read file: %w", err)
+	}
+	r.Data = fileContent.Bytes()
+
+	return r, nil
+}
+
+func (c Client) List(ctx context.Context, filter string) (ListResponse, error) {
+	type listResponse struct {
+		TotalCount  int        `json:"totalCount"`
+		Documents   []Response `json:"documents"`
+		NextPageKey *string    `json:"nextPageKey"`
+	}
+
+	var retVal ListResponse
+	var result listResponse
+	var initialPage = ""
+	result.NextPageKey = &initialPage
+
+	for result.NextPageKey != nil {
+
+		queryParams := url.Values{"filter": {filter}}
+		if *result.NextPageKey != "" {
+			queryParams["page-key"] = []string{*result.NextPageKey}
+		}
+
+		ro := rest.RequestOptions{
+			QueryParams: queryParams,
+		}
+
+		resp, err := c.client.List(ctx, ro)
+		if err != nil {
+			return ListResponse{}, err
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			return ListResponse{}, err
+		}
+
+		if !rest.IsSuccess(resp) {
+			return ListResponse{
+				Response: api.Response{
+					StatusCode: resp.StatusCode,
+					Data:       body,
+					Request:    rest.RequestInfo{Method: resp.Request.Method, URL: resp.Request.URL.String()},
+				},
+				Responses: nil,
+			}, nil
+
+		}
+
+		err = json.Unmarshal(body, &result)
+		if err != nil {
+			return ListResponse{}, err
+		}
+
+		for i := range result.Documents {
+			result.Documents[i].Request = rest.RequestInfo{Method: resp.Request.Method, URL: resp.Request.URL.String()}
+			result.Documents[i].StatusCode = resp.StatusCode
+		}
+
+		retVal.Responses = append(retVal.Responses, result.Documents...)
+		retVal.StatusCode = resp.StatusCode
+	}
+
+	return retVal, nil
+}
+
+func (c Client) Create(ctx context.Context, name string, data []byte, documentType DocumentType) (Response, error) {
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+
+	if err := writer.WriteField("type", documentTypesValues[documentType]); err != nil {
+		return Response{}, err
+	}
+	if err := writer.WriteField("name", name); err != nil {
+		return Response{}, err
+	}
+
+	part, err := writer.CreatePart(map[string][]string{
+		"Content-Type":        {"application/json"},
+		"Content-Disposition": {fmt.Sprintf(`form-data; name="content"; filename="%s"`, name)},
+	})
+	if err != nil {
+		return Response{}, err
+	}
+
+	if _, err = part.Write(data); err != nil {
+		return Response{}, err
+	}
+	if err = writer.Close(); err != nil {
+		return Response{}, err
+	}
+
+	resp, err := c.client.Create(ctx, body.Bytes(), rest.RequestOptions{
+		ContentType: writer.FormDataContentType(),
+	})
+	if err != nil {
+		return Response{}, err
+	}
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return Response{}, err
+	}
+
+	if err = resp.Body.Close(); err != nil {
+		return Response{}, err
+	}
+
+	r := Response{
+		Response: api.Response{
+			StatusCode: resp.StatusCode,
+			Data:       respBody,
+			Request:    rest.RequestInfo{Method: resp.Request.Method, URL: resp.Request.URL.String()},
+		},
+	}
+	if !rest.IsSuccess(resp) {
+		return r, nil
+	}
+
+	if err = json.Unmarshal(respBody, &r); err != nil {
+		return r, err
+	}
+
+	return r, nil
+}
+
+func (c Client) Update(ctx context.Context, id string, name string, data []byte, documentType DocumentType) (Response, error) {
+	if id == "" {
+		return Response{}, fmt.Errorf("id must be non empty")
+	}
+
+	getResp, err := c.Get(ctx, id)
+	if err != nil {
+		return Response{}, err
+	}
+
+	if !(getResp.StatusCode >= 200 && getResp.StatusCode <= 299) {
+		return getResp, nil
+	}
+
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+
+	if err = writer.WriteField("type", documentTypesValues[documentType]); err != nil {
+		return getResp, err
+	}
+	if err = writer.WriteField("name", name); err != nil {
+		return getResp, err
+	}
+
+	part, err := writer.CreatePart(map[string][]string{
+		"Content-Type":        {"application/json"},
+		"Content-Disposition": {fmt.Sprintf(`form-data; name="content"; filename="%s"`, name)},
+	})
+	if err != nil {
+		return getResp, err
+	}
+
+	if _, err = part.Write(data); err != nil {
+		return Response{}, err
+	}
+	if err = writer.Close(); err != nil {
+		return Response{}, err
+	}
+
+	patchResp, err := c.client.Patch(ctx, id, body.Bytes(), rest.RequestOptions{
+		QueryParams: map[string][]string{optimisticLockingHeader: {fmt.Sprint(getResp.Version)}},
+		ContentType: writer.FormDataContentType(),
+	})
+
+	if err != nil {
+		return Response{}, err
+	}
+
+	respBody, err := io.ReadAll(patchResp.Body)
+	if err != nil {
+		return Response{}, fmt.Errorf("failed to read response body: %w", err)
+	}
+	if err = patchResp.Body.Close(); err != nil {
+		return Response{}, err
+	}
+
+	if !rest.IsSuccess(patchResp) {
+		return Response{
+			Response: api.Response{
+				StatusCode: patchResp.StatusCode,
+				Data:       respBody,
+				Request:    rest.RequestInfo{Method: patchResp.Request.Method, URL: patchResp.Request.URL.String()},
+			},
+		}, nil
+	}
+
+	type documentMetaData struct {
+		ID         string `json:"id"`
+		ExternalID string `json:"externalId"`
+		Actor      string `json:"actor"`
+		Owner      string `json:"owner"`
+		Name       string `json:"name"`
+		Type       string `json:"type"`
+		Version    int    `json:"version"`
+	}
+	type metadata struct {
+		DocumentMetaData documentMetaData `json:"documentMetadata"`
+	}
+
+	var r metadata
+	if err = json.Unmarshal(respBody, &r); err != nil {
+		return Response{}, err
+	}
+
+	return Response{
+		ID:      r.DocumentMetaData.ID,
+		Actor:   r.DocumentMetaData.Actor,
+		Owner:   r.DocumentMetaData.Owner,
+		Name:    r.DocumentMetaData.Name,
+		Type:    r.DocumentMetaData.Type,
+		Version: r.DocumentMetaData.Version,
+
+		Response: api.Response{
+			StatusCode: patchResp.StatusCode,
+			Data:       respBody,
+			Request:    rest.RequestInfo{Method: patchResp.Request.Method, URL: patchResp.Request.URL.String()},
+		},
+	}, nil
+
+}
+
+func (c Client) Upsert(ctx context.Context, id string, name string, data []byte, documentType DocumentType) (Response, error) {
+	if id == "" {
+		return Response{}, fmt.Errorf("id must be non empty")
+	}
+
+	resp, err := c.Update(ctx, id, name, data, documentType)
+	if err != nil {
+		return Response{}, err
+	}
+
+	if resp.IsSuccess() {
+		return resp, err
+	}
+
+	if resp.StatusCode == http.StatusNotFound {
+		return c.Create(ctx, name, data, documentType)
+	}
+
+	return resp, nil
+
+}
+
+func (c Client) Delete(ctx context.Context, id string) (Response, error) {
+	if id == "" {
+		return Response{}, fmt.Errorf("id must be non empty")
+	}
+
+	getResp, err := c.Get(ctx, id)
+	if err != nil {
+		return Response{}, err
+	}
+
+	if !(getResp.StatusCode >= 200 && getResp.StatusCode <= 299) {
+		return Response{
+			Response: api.Response{
+				StatusCode: getResp.StatusCode,
+				Request:    rest.RequestInfo{Method: getResp.Request.Method, URL: getResp.Request.URL},
+			},
+		}, nil
+	}
+
+	resp, err := c.client.Delete(ctx, id, rest.RequestOptions{
+		QueryParams: map[string][]string{optimisticLockingHeader: {fmt.Sprint(getResp.Version)}},
+	})
+	if err != nil {
+		return Response{}, err
+	}
+
+	return Response{
+		Response: api.Response{
+			StatusCode: resp.StatusCode,
+			Data:       nil,
+			Request:    rest.RequestInfo{Method: resp.Request.Method, URL: resp.Request.URL.String()},
+		},
+	}, nil
+}

--- a/clients/documents/documents_test.go
+++ b/clients/documents/documents_test.go
@@ -1,7 +1,22 @@
+// @license
+// Copyright 2023 Dynatrace LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package documents_test
 
 import (
 	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/documents"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/testutils"
@@ -114,8 +129,10 @@ This is the document content
 		client := documents.NewClient(rest.NewClient(server.URL(), server.Client()))
 		ctx := testutils.ContextWithLogger(t)
 		resp, err := client.Get(ctx, "b17ec54b-07ac-4c73-9c4d-232e1b2e2420")
-		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-		assert.NoError(t, err)
+		assert.Zero(t, resp)
+		var apiError api.APIError
+		assert.ErrorAs(t, err, &apiError)
+		assert.Equal(t, http.StatusBadRequest, apiError.StatusCode)
 	})
 }
 
@@ -182,8 +199,11 @@ func TestDocumentClient_Create(t *testing.T) {
 		ctx := testutils.ContextWithLogger(t)
 		resp, err := client.Create(ctx, "my-dashboard", []byte(payload), documents.Dashboard)
 
-		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
-		assert.NoError(t, err)
+		assert.Zero(t, resp)
+		var apiError api.APIError
+		assert.ErrorAs(t, err, &apiError)
+		assert.Equal(t, http.StatusInternalServerError, apiError.StatusCode)
+
 	})
 
 	t.Run("Create - Unable to make HTTP POST call", func(t *testing.T) {
@@ -344,8 +364,12 @@ This is the document content
 
 		ctx := testutils.ContextWithLogger(t)
 		resp, err := client.Upsert(ctx, "038ab74f-0a3a-4bf8-9068-85e2d633a1e6", "my-dashboard", []byte(payload), documents.Dashboard)
-		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
-		assert.NoError(t, err)
+
+		assert.Zero(t, resp)
+		var apiError api.APIError
+		assert.ErrorAs(t, err, &apiError)
+		assert.Equal(t, http.StatusInternalServerError, apiError.StatusCode)
+
 	})
 
 	t.Run("Upsert - Existing Document Found - Updates it", func(t *testing.T) {
@@ -409,8 +433,11 @@ This is the document content
 
 		ctx := testutils.ContextWithLogger(t)
 		resp, err := client.Upsert(ctx, "038ab74f-0a3a-4bf8-9068-85e2d633a1e6", "my-dashboard", []byte(payload), documents.Dashboard)
-		assert.NoError(t, err)
-		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+
+		assert.Zero(t, resp)
+		var apiError api.APIError
+		assert.ErrorAs(t, err, &apiError)
+		assert.Equal(t, http.StatusInternalServerError, apiError.StatusCode)
 	})
 }
 
@@ -542,9 +569,13 @@ func TestDocumentClient_List(t *testing.T) {
 		client := documents.NewClient(rest.NewClient(server.URL(), server.Client()))
 		ctx := testutils.ContextWithLogger(t)
 		resp, err := client.List(ctx, "")
+
+		assert.Zero(t, resp)
+		var apiError api.APIError
+		assert.ErrorAs(t, err, &apiError)
+		assert.Equal(t, http.StatusInternalServerError, apiError.StatusCode)
 		assert.Len(t, resp.Responses, 0)
-		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
-		assert.NoError(t, err)
+
 	})
 
 	t.Run("List - Request Fails", func(t *testing.T) {
@@ -655,9 +686,12 @@ This is the document content
 		client := documents.NewClient(rest.NewClient(server.URL(), server.Client()))
 		ctx := testutils.ContextWithLogger(t)
 		resp, err := client.Delete(ctx, "id-of-document")
-		assert.NotZero(t, resp)
-		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
-		assert.NoError(t, err)
+
+		assert.Zero(t, resp)
+		var apiError api.APIError
+		assert.ErrorAs(t, err, &apiError)
+		assert.Equal(t, http.StatusNotFound, apiError.StatusCode)
+
 	})
 
 	t.Run("Delete - Failed to execut Request", func(t *testing.T) {

--- a/clients/documents/documents_test.go
+++ b/clients/documents/documents_test.go
@@ -1,0 +1,675 @@
+package documents_test
+
+import (
+	"fmt"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/documents"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/testutils"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"testing"
+)
+
+func TestDocumentClient_Get(t *testing.T) {
+	const payload = `--Aas2UU1KdxSpaAyiNZ4-tnuzbwqnKuNK8vMOGy
+Content-Disposition: form-data; name="metadata"
+Content-Type: application/json
+
+{
+    "modificationInfo": {
+        "createdBy": "12341234-1234-1234-1234-12341234",
+        "createdTime": "2024-04-11T12:31:33.599Z",
+        "lastModifiedBy": "2f321c04-566e-4779-b576-3c033b8cd9e9",
+        "lastModifiedTime": "2024-04-11T12:31:33.599Z"
+    },
+    "access": [
+        "read",
+        "delete",
+        "write"
+    ],
+    "id": "b17ec54b-07ac-4c73-9c4d-232e1b2e2420",
+    "name": "my-test-db",
+    "type": "dashboard",
+    "version": 1,
+    "owner": "12341234-1234-1234-1234-12341234"
+}
+--Aas2UU1KdxSpaAyiNZ4-tnuzbwqnKuNK8vMOGy
+Content-Disposition: form-data; name="content"; filename="my-test-db"
+Content-Type: application/json
+
+This is the document content
+--Aas2UU1KdxSpaAyiNZ4-tnuzbwqnKuNK8vMOGy--
+`
+
+	t.Run("Get - no ID given", func(t *testing.T) {
+		responses := []testutils.ResponseDef{}
+		server := testutils.NewHTTPTestServer(t, responses)
+		defer server.Close()
+
+		client := documents.NewClient(rest.NewClient(server.URL(), server.Client()))
+		ctx := testutils.ContextWithLogger(t)
+		resp, err := client.Get(ctx, "")
+		assert.Zero(t, resp)
+		assert.NotNil(t, err)
+	})
+	t.Run("GET - OK", func(t *testing.T) {
+
+		responses := []testutils.ResponseDef{
+			{
+				GET: func(t *testing.T, req *http.Request) testutils.Response {
+					return testutils.Response{
+						ResponseCode: http.StatusOK,
+						ResponseBody: payload,
+						ContentType:  "multipart/form-data;boundary=Aas2UU1KdxSpaAyiNZ4-tnuzbwqnKuNK8vMOGy",
+					}
+				},
+			},
+		}
+
+		server := testutils.NewHTTPTestServer(t, responses)
+		defer server.Close()
+
+		client := documents.NewClient(rest.NewClient(server.URL(), server.Client()))
+		ctx := testutils.ContextWithLogger(t)
+		resp, err := client.Get(ctx, "b17ec54b-07ac-4c73-9c4d-232e1b2e2420")
+		assert.NotZero(t, resp)
+		assert.Equal(t, "b17ec54b-07ac-4c73-9c4d-232e1b2e2420", resp.ID)
+		assert.Equal(t, "my-test-db", resp.Name)
+		assert.Equal(t, "dashboard", resp.Type)
+		assert.Equal(t, 1, resp.Version)
+		assert.Equal(t, "12341234-1234-1234-1234-12341234", resp.Owner)
+		assert.Equal(t, "This is the document content", string(resp.Data))
+		assert.NotZero(t, resp.Request)
+		assert.Nil(t, err)
+
+	})
+
+	t.Run("GET - Unable to make HTTP call", func(t *testing.T) {
+
+		responses := []testutils.ResponseDef{}
+		server := testutils.NewHTTPTestServer(t, responses)
+		defer server.Close()
+
+		client := documents.NewClient(rest.NewClient(server.URL(), server.FaultyClient()))
+		ctx := testutils.ContextWithLogger(t)
+		resp, err := client.Get(ctx, "b17ec54b-07ac-4c73-9c4d-232e1b2e2420")
+		assert.Zero(t, resp)
+		assert.Error(t, err)
+	})
+
+	t.Run("GET - API Call returned with != 2xx", func(t *testing.T) {
+		responses := []testutils.ResponseDef{
+			{
+				GET: func(t *testing.T, req *http.Request) testutils.Response {
+					return testutils.Response{
+						ResponseCode: http.StatusBadRequest,
+					}
+				},
+			},
+		}
+
+		server := testutils.NewHTTPTestServer(t, responses)
+		defer server.Close()
+
+		client := documents.NewClient(rest.NewClient(server.URL(), server.Client()))
+		ctx := testutils.ContextWithLogger(t)
+		resp, err := client.Get(ctx, "b17ec54b-07ac-4c73-9c4d-232e1b2e2420")
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		assert.NoError(t, err)
+	})
+}
+
+func TestDocumentClient_Create(t *testing.T) {
+	const payload = `{
+    "modificationInfo": {
+        "createdBy": "12341234-1234-1234-1234-12341234",
+        "createdTime": "2024-04-11T14:06:26.491Z",
+        "lastModifiedBy": "2f321c04-566e-4779-b576-3c033b8cd9e9",
+        "lastModifiedTime": "2024-04-11T14:06:26.491Z"
+    },
+    "access": [
+        "read",
+        "delete",
+        "write"
+    ],
+    "id": "038ab74f-0a3a-4bf8-9068-85e2d633a1e6",
+    "name": "my-test-db",
+    "type": "dashboard",
+    "version": 1,
+    "owner": "12341234-1234-1234-1234-12341234"
+}`
+
+	t.Run("Create  - OK", func(t *testing.T) {
+		responses := []testutils.ResponseDef{
+			{
+				POST: func(t *testing.T, req *http.Request) testutils.Response {
+					return testutils.Response{
+						ResponseCode: http.StatusCreated,
+						ResponseBody: payload,
+					}
+				},
+			},
+		}
+
+		server := testutils.NewHTTPTestServer(t, responses)
+		defer server.Close()
+
+		client := documents.NewClient(rest.NewClient(server.URL(), server.Client()))
+
+		ctx := testutils.ContextWithLogger(t)
+		resp, err := client.Create(ctx, "my-dashboard", []byte(payload), documents.Dashboard)
+		assert.NotNil(t, resp)
+		assert.Equal(t, payload, string(resp.Data))
+		assert.NoError(t, err)
+	})
+
+	t.Run("Create - API Call returned with != 2xx", func(t *testing.T) {
+
+		responses := []testutils.ResponseDef{
+			{
+				POST: func(t *testing.T, req *http.Request) testutils.Response {
+					return testutils.Response{
+						ResponseCode: http.StatusInternalServerError,
+						ResponseBody: "{}"}
+				},
+			},
+		}
+
+		server := testutils.NewHTTPTestServer(t, responses)
+		defer server.Close()
+
+		client := documents.NewClient(rest.NewClient(server.URL(), server.Client()))
+		ctx := testutils.ContextWithLogger(t)
+		resp, err := client.Create(ctx, "my-dashboard", []byte(payload), documents.Dashboard)
+
+		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+		assert.NoError(t, err)
+	})
+
+	t.Run("Create - Unable to make HTTP POST call", func(t *testing.T) {
+
+		responses := []testutils.ResponseDef{
+			{
+				POST: func(t *testing.T, req *http.Request) testutils.Response {
+					return testutils.Response{
+						ResponseCode: http.StatusCreated,
+						ResponseBody: payload,
+					}
+				},
+			},
+		}
+
+		server := testutils.NewHTTPTestServer(t, responses)
+		defer server.Close()
+
+		client := documents.NewClient(rest.NewClient(server.URL(), server.FaultyClient()))
+		ctx := testutils.ContextWithLogger(t)
+		resp, err := client.Create(ctx, "my-dashboard", []byte(payload), documents.Dashboard)
+		assert.Zero(t, resp)
+		assert.Error(t, err)
+	})
+}
+
+func TestDocumentClient_Upsert(t *testing.T) {
+	const getPayload = `--Aas2UU1KdxSpaAyiNZ4-tnuzbwqnKuNK8vMOGy
+Content-Disposition: form-data; name="metadata"
+Content-Type: application/json
+
+{
+    "modificationInfo": {
+        "createdBy": "12341234-1234-1234-1234-12341234",
+        "createdTime": "2024-04-11T12:31:33.599Z",
+        "lastModifiedBy": "2f321c04-566e-4779-b576-3c033b8cd9e9",
+        "lastModifiedTime": "2024-04-11T12:31:33.599Z"
+    },
+    "access": [
+        "read",
+        "delete",
+        "write"
+    ],
+    "id": "b17ec54b-07ac-4c73-9c4d-232e1b2e2420",
+    "name": "my-test-db",
+    "type": "dashboard",
+    "version": 1,
+    "owner": "12341234-1234-1234-1234-12341234"
+}
+--Aas2UU1KdxSpaAyiNZ4-tnuzbwqnKuNK8vMOGy
+Content-Disposition: form-data; name="content"; filename="my-test-db"
+Content-Type: application/json
+
+This is the document content
+--Aas2UU1KdxSpaAyiNZ4-tnuzbwqnKuNK8vMOGy--
+`
+	const payload = `{
+    "modificationInfo": {
+        "createdBy": "12341234-1234-1234-1234-12341234",
+        "createdTime": "2024-04-11T14:06:26.491Z",
+        "lastModifiedBy": "2f321c04-566e-4779-b576-3c033b8cd9e9",
+        "lastModifiedTime": "2024-04-11T14:06:26.491Z"
+    },
+    "access": [
+        "read",
+        "delete",
+        "write"
+    ],
+    "id": "038ab74f-0a3a-4bf8-9068-85e2d633a1e6",
+    "name": "my-test-db",
+    "type": "dashboard",
+    "version": 1,
+    "owner": "12341234-1234-1234-1234-12341234"
+}`
+
+	const patchPayload = `{
+  "documentMetadata": {
+    "modificationInfo": {
+      "createdBy": "12341234-1234-1234-1234-12341234",
+      "createdTime": "2024-04-11T14:06:26.491Z",
+      "lastModifiedBy": "2f321c04-566e-4779-b576-3c033b8cd9e9",
+      "lastModifiedTime": "2024-04-11T14:06:26.491Z"
+    },
+    "access": [
+      "read",
+      "delete",
+      "write"
+    ],
+    "id": "038ab74f-0a3a-4bf8-9068-85e2d633a1e6",
+    "name": "my-test-db",
+    "type": "dashboard",
+    "version": 1,
+    "owner": "12341234-1234-1234-1234-12341234"
+  }
+}`
+
+	t.Run("Upsert - Missing id", func(t *testing.T) {
+		responses := []testutils.ResponseDef{}
+
+		server := testutils.NewHTTPTestServer(t, responses)
+		defer server.Close()
+
+		client := documents.NewClient(rest.NewClient(server.URL(), server.Client()))
+
+		ctx := testutils.ContextWithLogger(t)
+		resp, err := client.Upsert(ctx, "", "my-dashboard", []byte(payload), documents.Dashboard)
+		assert.Zero(t, resp)
+		assert.Error(t, err)
+	})
+
+	t.Run("Upsert - No document found - Creates new Document  - OK", func(t *testing.T) {
+		responses := []testutils.ResponseDef{
+			{
+				GET: func(t *testing.T, request *http.Request) testutils.Response {
+					return testutils.Response{
+						ResponseCode: http.StatusNotFound,
+					}
+				},
+			},
+			{
+				POST: func(t *testing.T, req *http.Request) testutils.Response {
+					return testutils.Response{
+						ResponseCode: http.StatusCreated,
+						ResponseBody: payload,
+					}
+				},
+			},
+		}
+
+		server := testutils.NewHTTPTestServer(t, responses)
+		defer server.Close()
+
+		client := documents.NewClient(rest.NewClient(server.URL(), server.Client()))
+
+		ctx := testutils.ContextWithLogger(t)
+		resp, err := client.Upsert(ctx, "038ab74f-0a3a-4bf8-9068-85e2d633a1e6", "my-dashboard", []byte(payload), documents.Dashboard)
+		assert.NotNil(t, resp)
+		assert.Equal(t, payload, string(resp.Data))
+		assert.Equal(t, http.StatusCreated, resp.StatusCode)
+		assert.NoError(t, err)
+	})
+
+	t.Run("Upsert - Fails to fetch existing document", func(t *testing.T) {
+		responses := []testutils.ResponseDef{
+			{
+				GET: func(t *testing.T, request *http.Request) testutils.Response {
+					return testutils.Response{
+						ResponseCode: http.StatusInternalServerError,
+					}
+				},
+			},
+		}
+
+		server := testutils.NewHTTPTestServer(t, responses)
+		defer server.Close()
+
+		client := documents.NewClient(rest.NewClient(server.URL(), server.Client()))
+
+		ctx := testutils.ContextWithLogger(t)
+		resp, err := client.Upsert(ctx, "038ab74f-0a3a-4bf8-9068-85e2d633a1e6", "my-dashboard", []byte(payload), documents.Dashboard)
+		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+		assert.NoError(t, err)
+	})
+
+	t.Run("Upsert - Existing Document Found - Updates it", func(t *testing.T) {
+		responses := []testutils.ResponseDef{
+			{
+				GET: func(t *testing.T, request *http.Request) testutils.Response {
+					return testutils.Response{
+						ResponseCode: http.StatusOK,
+						ResponseBody: getPayload,
+						ContentType:  "multipart/form-data;boundary=Aas2UU1KdxSpaAyiNZ4-tnuzbwqnKuNK8vMOGy",
+					}
+				},
+			},
+			{
+				PATCH: func(t *testing.T, req *http.Request) testutils.Response {
+					return testutils.Response{
+						ResponseCode: http.StatusOK,
+						ResponseBody: patchPayload,
+					}
+				},
+			},
+		}
+
+		server := testutils.NewHTTPTestServer(t, responses)
+		defer server.Close()
+
+		client := documents.NewClient(rest.NewClient(server.URL(), server.Client()))
+
+		ctx := testutils.ContextWithLogger(t)
+		resp, err := client.Upsert(ctx, "038ab74f-0a3a-4bf8-9068-85e2d633a1e6", "my-dashboard", []byte(payload), documents.Dashboard)
+		assert.NoError(t, err)
+		assert.Equal(t, patchPayload, string(resp.Data))
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		fmt.Println(resp.ID)
+	})
+
+	t.Run("Upsert - Existing Document Found - Update fails", func(t *testing.T) {
+		responses := []testutils.ResponseDef{
+			{
+				GET: func(t *testing.T, request *http.Request) testutils.Response {
+					return testutils.Response{
+						ResponseCode: http.StatusOK,
+						ResponseBody: getPayload,
+						ContentType:  "multipart/form-data;boundary=Aas2UU1KdxSpaAyiNZ4-tnuzbwqnKuNK8vMOGy",
+					}
+				},
+			},
+			{
+				PATCH: func(t *testing.T, req *http.Request) testutils.Response {
+					return testutils.Response{
+						ResponseCode: http.StatusInternalServerError,
+					}
+				},
+			},
+		}
+
+		server := testutils.NewHTTPTestServer(t, responses)
+		defer server.Close()
+
+		client := documents.NewClient(rest.NewClient(server.URL(), server.Client()))
+
+		ctx := testutils.ContextWithLogger(t)
+		resp, err := client.Upsert(ctx, "038ab74f-0a3a-4bf8-9068-85e2d633a1e6", "my-dashboard", []byte(payload), documents.Dashboard)
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	})
+}
+
+func TestDocumentClient_List(t *testing.T) {
+	const listPayloadPage1 = `{
+    "documents": [
+        {
+            "modificationInfo": {
+                "createdBy": "12341234-1234-1234-1234-12341234",
+                "createdTime": "2024-04-10T17:21:06.797Z",
+                "lastModifiedBy": "2f321c04-566e-4779-b576-3c033b8cd9e9",
+                "lastModifiedTime": "2024-04-10T17:21:06.797Z"
+            },
+            "access": [
+                "read",
+                "write",
+                "delete"
+            ],
+            "id": "id1",
+            "name": "name1",
+            "type": "dashboard",
+            "version": 1,
+            "owner": "owner1"
+        }
+    ],
+    "nextPageKey": "next",
+    "totalCount": 2
+}`
+
+	const listPayloadPage2 = `{
+    "documents": [
+        {
+            "modificationInfo": {
+                "createdBy": "12341234-1234-1234-1234-12341234",
+                "createdTime": "2024-04-10T17:21:06.797Z",
+                "lastModifiedBy": "2f321c04-566e-4779-b576-3c033b8cd9e9",
+                "lastModifiedTime": "2024-04-10T17:21:06.797Z"
+            },
+            "access": [
+                "read",
+                "write",
+                "delete"
+            ],
+            "id": "id2",
+            "name": "name2",
+            "type": "dashboard",
+            "version": 1,
+            "owner": "owner2"
+        }
+    ],
+    "nextPageKey": null,
+    "totalCount": 2
+}`
+
+	t.Run("List - OK", func(t *testing.T) {
+		responses := []testutils.ResponseDef{
+			{
+				GET: func(t *testing.T, req *http.Request) testutils.Response {
+					return testutils.Response{
+						ResponseCode: http.StatusOK,
+						ResponseBody: listPayloadPage1,
+					}
+				},
+				ValidateRequest: func(t *testing.T, request *http.Request) {
+					assert.Equal(t, "filter=type+%3D%3D+%27dashboard%27", request.URL.RawQuery)
+				},
+			},
+			{
+				GET: func(t *testing.T, req *http.Request) testutils.Response {
+					return testutils.Response{
+						ResponseCode: http.StatusOK,
+						ResponseBody: listPayloadPage2,
+					}
+				},
+				ValidateRequest: func(t *testing.T, request *http.Request) {
+					assert.Equal(t, "filter=type+%3D%3D+%27dashboard%27&page-key=next", request.URL.RawQuery)
+				},
+			},
+		}
+
+		server := testutils.NewHTTPTestServer(t, responses)
+		defer server.Close()
+
+		client := documents.NewClient(rest.NewClient(server.URL(), server.Client()))
+		ctx := testutils.ContextWithLogger(t)
+		resp, err := client.List(ctx, "type == 'dashboard'")
+		assert.Len(t, resp.Responses, 2)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.NoError(t, err)
+
+		assert.Equal(t, "id1", resp.Responses[0].ID)
+		assert.Equal(t, "name1", resp.Responses[0].Name)
+		assert.Equal(t, "dashboard", resp.Responses[0].Type)
+		assert.Equal(t, 1, resp.Responses[0].Version)
+		assert.Equal(t, "owner1", resp.Responses[0].Owner)
+		assert.Equal(t, http.StatusOK, resp.Responses[0].StatusCode)
+
+		assert.Equal(t, "id2", resp.Responses[1].ID)
+		assert.Equal(t, "name2", resp.Responses[1].Name)
+		assert.Equal(t, "dashboard", resp.Responses[1].Type)
+		assert.Equal(t, 1, resp.Responses[1].Version)
+		assert.Equal(t, "owner2", resp.Responses[1].Owner)
+		assert.Equal(t, http.StatusOK, resp.Responses[1].StatusCode)
+
+	})
+
+	t.Run("List - Loading Page Fails", func(t *testing.T) {
+		responses := []testutils.ResponseDef{
+			{
+				GET: func(t *testing.T, req *http.Request) testutils.Response {
+					return testutils.Response{
+						ResponseCode: http.StatusOK,
+						ResponseBody: listPayloadPage1,
+					}
+				},
+			},
+			{
+				GET: func(t *testing.T, req *http.Request) testutils.Response {
+					return testutils.Response{
+						ResponseCode: http.StatusInternalServerError,
+					}
+				},
+			},
+		}
+
+		server := testutils.NewHTTPTestServer(t, responses)
+		defer server.Close()
+
+		client := documents.NewClient(rest.NewClient(server.URL(), server.Client()))
+		ctx := testutils.ContextWithLogger(t)
+		resp, err := client.List(ctx, "")
+		assert.Len(t, resp.Responses, 0)
+		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+		assert.NoError(t, err)
+	})
+
+	t.Run("List - Request Fails", func(t *testing.T) {
+		responses := []testutils.ResponseDef{}
+
+		server := testutils.NewHTTPTestServer(t, responses)
+		defer server.Close()
+
+		client := documents.NewClient(rest.NewClient(server.URL(), server.FaultyClient()))
+		ctx := testutils.ContextWithLogger(t)
+		resp, err := client.List(ctx, "")
+		assert.Zero(t, resp)
+		assert.Error(t, err)
+	})
+}
+
+func TestDocumentClient_Delete(t *testing.T) {
+
+	const getPayload = `--Aas2UU1KdxSpaAyiNZ4-tnuzbwqnKuNK8vMOGy
+Content-Disposition: form-data; name="metadata"
+Content-Type: application/json
+
+{
+    "modificationInfo": {
+        "createdBy": "12341234-1234-1234-1234-12341234",
+        "createdTime": "2024-04-11T12:31:33.599Z",
+        "lastModifiedBy": "2f321c04-566e-4779-b576-3c033b8cd9e9",
+        "lastModifiedTime": "2024-04-11T12:31:33.599Z"
+    },
+    "access": [
+        "read",
+        "delete",
+        "write"
+    ],
+    "id": "b17ec54b-07ac-4c73-9c4d-232e1b2e2420",
+    "name": "my-test-db",
+    "type": "dashboard",
+    "version": 1,
+    "owner": "12341234-1234-1234-1234-12341234"
+}
+--Aas2UU1KdxSpaAyiNZ4-tnuzbwqnKuNK8vMOGy
+Content-Disposition: form-data; name="content"; filename="my-test-db"
+Content-Type: application/json
+
+This is the document content
+--Aas2UU1KdxSpaAyiNZ4-tnuzbwqnKuNK8vMOGy--
+`
+
+	t.Run("Delete - id missing", func(t *testing.T) {
+		responses := []testutils.ResponseDef{}
+
+		server := testutils.NewHTTPTestServer(t, responses)
+		defer server.Close()
+
+		client := documents.NewClient(rest.NewClient(server.URL(), server.Client()))
+		ctx := testutils.ContextWithLogger(t)
+		resp, err := client.Delete(ctx, "")
+		assert.Zero(t, resp)
+		assert.Error(t, err)
+
+	})
+
+	t.Run("Delete - OK", func(t *testing.T) {
+		responses := []testutils.ResponseDef{
+			{
+				GET: func(t *testing.T, req *http.Request) testutils.Response {
+					return testutils.Response{
+						ResponseCode: http.StatusOK,
+						ResponseBody: getPayload,
+						ContentType:  "multipart/form-data;boundary=Aas2UU1KdxSpaAyiNZ4-tnuzbwqnKuNK8vMOGy",
+					}
+				},
+			},
+			{
+				DELETE: func(t *testing.T, req *http.Request) testutils.Response {
+					return testutils.Response{
+						ResponseCode: http.StatusOK,
+					}
+				},
+			},
+		}
+
+		server := testutils.NewHTTPTestServer(t, responses)
+		defer server.Close()
+
+		client := documents.NewClient(rest.NewClient(server.URL(), server.Client()))
+		ctx := testutils.ContextWithLogger(t)
+		resp, err := client.Delete(ctx, "id-of-document")
+		assert.NotZero(t, resp)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.NoError(t, err)
+	})
+
+	t.Run("Delete - Fails finding existing document", func(t *testing.T) {
+		responses := []testutils.ResponseDef{
+			{
+				GET: func(t *testing.T, req *http.Request) testutils.Response {
+					return testutils.Response{
+						ResponseCode: http.StatusNotFound,
+					}
+				},
+			},
+		}
+
+		server := testutils.NewHTTPTestServer(t, responses)
+		defer server.Close()
+
+		client := documents.NewClient(rest.NewClient(server.URL(), server.Client()))
+		ctx := testutils.ContextWithLogger(t)
+		resp, err := client.Delete(ctx, "id-of-document")
+		assert.NotZero(t, resp)
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+		assert.NoError(t, err)
+	})
+
+	t.Run("Delete - Failed to execut Request", func(t *testing.T) {
+		responses := []testutils.ResponseDef{}
+
+		server := testutils.NewHTTPTestServer(t, responses)
+		defer server.Close()
+
+		client := documents.NewClient(rest.NewClient(server.URL(), server.FaultyClient()))
+		ctx := testutils.ContextWithLogger(t)
+		resp, err := client.Delete(ctx, "id-of-document")
+		assert.Zero(t, resp)
+		assert.Error(t, err)
+	})
+}

--- a/clients/factory.go
+++ b/clients/factory.go
@@ -23,6 +23,7 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/automation"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/buckets"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/documents"
 	"golang.org/x/oauth2/clientcredentials"
 	"net/url"
 	"time"
@@ -105,6 +106,15 @@ func (f factory) BucketClient() (*buckets.Client, error) {
 		return nil, err
 	}
 	return buckets.NewClient(restClient), nil
+}
+
+// DocumentClient creates and returns a new instance of documents.Client for interacting with the document API.
+func (f factory) DocumentClient() (*documents.Client, error) {
+	restClient, err := f.createClient()
+	if err != nil {
+		return nil, err
+	}
+	return documents.NewClient(restClient), nil
 }
 
 // BucketClientWithRetrySettings creates and returns a new instance of buckets.Client with non-default retry settings.

--- a/clients/factory_test.go
+++ b/clients/factory_test.go
@@ -17,6 +17,7 @@ package clients
 import (
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/automation"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/buckets"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/documents"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/oauth2/clientcredentials"
 	"testing"
@@ -45,6 +46,11 @@ func TestClientCreation(t *testing.T) {
 	assert.NotNil(t, clientInstance)
 	assert.IsType(t, &automation.Client{}, clientInstance)
 
+	clientInstance, err = f.DocumentClient()
+	assert.NoError(t, err)
+	assert.NotNil(t, clientInstance)
+	assert.IsType(t, &documents.Client{}, clientInstance)
+
 	//... other clients
 }
 
@@ -70,6 +76,11 @@ func TestClientMissingEnvironmentURL(t *testing.T) {
 	assert.Nil(t, clientInstance)
 	assert.ErrorIs(t, err, ErrEnvironmentURLMissing)
 
+	clientInstance, err = f.DocumentClient()
+	assert.Error(t, err)
+	assert.Nil(t, clientInstance)
+	assert.ErrorIs(t, err, ErrEnvironmentURLMissing)
+
 	//... other clients
 }
 
@@ -87,6 +98,11 @@ func TestClientMissingOAuthCredentials(t *testing.T) {
 	assert.ErrorIs(t, err, ErrOAuthCredentialsMissing)
 
 	clientInstance, err = f.AutomationClient()
+	assert.Error(t, err)
+	assert.Nil(t, clientInstance)
+	assert.ErrorIs(t, err, ErrOAuthCredentialsMissing)
+
+	clientInstance, err = f.DocumentClient()
 	assert.Error(t, err)
 	assert.Nil(t, clientInstance)
 	assert.ErrorIs(t, err, ErrOAuthCredentialsMissing)
@@ -113,6 +129,11 @@ func TestClientURLParsingError(t *testing.T) {
 	assert.ErrorContains(t, err, "failed to parse URL")
 
 	clientInstance, err = f.AutomationClient()
+	assert.Error(t, err)
+	assert.Nil(t, clientInstance)
+	assert.ErrorContains(t, err, "failed to parse URL")
+
+	clientInstance, err = f.DocumentClient()
 	assert.Error(t, err)
 	assert.Nil(t, clientInstance)
 	assert.ErrorContains(t, err, "failed to parse URL")


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code-core/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
This PR introduces the http client for document support.

#### Special notes for your reviewer:
We've discussed a bit about our current approach of returning errors **only** if any HTTP call did not work.
While this is fine for the basic clients (which only make single http requests) it is a bit awkward for smart clients that have methods like e.g. Upsert which involves multiple HTTP calls.

I've [changed](https://github.com/Dynatrace/dynatrace-configuration-as-code-core/pull/91/commits/08d8e469c1d76fecafd7082471641a5098426b23) the code so that errors are also returned in case of api errors (return codes != 2xx). In this case an APIError value and a zero value'd Response is returned

In a follow-up the existing smart clients for automation and buckets should be changed accordingly)


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
