### PR TITLE
chore: Update automation client to return API errors 

### DIFF
--- a/clients/automation/automation_test.go
+++ b/clients/automation/automation_test.go
@@ -103,8 +103,11 @@ func TestAutomationClient_Get(t *testing.T) {
 		client := automation.NewClient(rest.NewClient(server.URL(), server.Client()))
 		ctx := testutils.ContextWithLogger(t)
 		resp, err := client.Get(ctx, apiClient.Workflows, "91cc8988-2223-404a-a3f5-5f1a839ecd45")
-		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-		assert.NoError(t, err)
+
+		assert.Zero(t, resp)
+		var apiError api.APIError
+		assert.ErrorAs(t, err, &apiError)
+		assert.Equal(t, http.StatusBadRequest, apiError.StatusCode)
 	})
 }
 
@@ -155,8 +158,10 @@ func TestAutomationClient_Create(t *testing.T) {
 		ctx := testutils.ContextWithLogger(t)
 		resp, err := client.Create(ctx, apiClient.Workflows, []byte(payload))
 
-		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
-		assert.NoError(t, err)
+		assert.Zero(t, resp)
+		var apiError api.APIError
+		assert.ErrorAs(t, err, &apiError)
+		assert.Equal(t, http.StatusInternalServerError, apiError.StatusCode)
 	})
 
 	t.Run("Create - Unable to make HTTP POST call", func(t *testing.T) {
@@ -249,8 +254,10 @@ func TestAutomationClient_Update(t *testing.T) {
 		ctx := testutils.ContextWithLogger(t)
 		resp, err := client.Update(ctx, apiClient.Workflows, "91cc8988-2223-404a-a3f5-5f1a839ecd45", []byte(payload))
 
-		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
-		assert.NoError(t, err)
+		assert.Zero(t, resp)
+		var apiError api.APIError
+		assert.ErrorAs(t, err, &apiError)
+		assert.Equal(t, http.StatusInternalServerError, apiError.StatusCode)
 	})
 
 	t.Run("Update - HTTP PUT call is not possible", func(t *testing.T) {
@@ -447,9 +454,12 @@ func TestAutomationClient_Upsert(t *testing.T) {
 		ctx := testutils.ContextWithLogger(t)
 		data := []byte(`{"id" : "some-id"}`)
 		resp, err := client.Upsert(ctx, apiClient.Workflows, "91cc8988-2223-404a-a3f5-5f1a839ecd45", data)
-		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
 		assert.Equal(t, 3, server.Calls())
-		assert.Nil(t, err)
+		assert.Zero(t, resp)
+		var apiError api.APIError
+		assert.ErrorAs(t, err, &apiError)
+		assert.Equal(t, http.StatusInternalServerError, apiError.StatusCode)
+
 	})
 
 	t.Run("Upsert - Direct update using HTTP PUT API Call returned with != 2xx - creation via POST OK", func(t *testing.T) {
@@ -625,9 +635,11 @@ func TestAutomationClient_Delete(t *testing.T) {
 		client := automation.NewClient(rest.NewClient(server.URL(), server.Client()))
 		ctx := testutils.ContextWithLogger(t)
 		resp, err := client.Delete(ctx, apiClient.Workflows, "91cc8988-2223-404a-a3f5-5f1a839ecd45")
-		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
 		assert.Equal(t, 2, server.Calls())
-		assert.Nil(t, err)
+		assert.Zero(t, resp)
+		var apiError api.APIError
+		assert.ErrorAs(t, err, &apiError)
+		assert.Equal(t, http.StatusInternalServerError, apiError.StatusCode)
 	})
 
 	t.Run("Delete - adminAccess forbidden - resource not found", func(t *testing.T) {
@@ -649,9 +661,11 @@ func TestAutomationClient_Delete(t *testing.T) {
 		client := automation.NewClient(rest.NewClient(server.URL(), server.Client()))
 		ctx := testutils.ContextWithLogger(t)
 		resp, err := client.Delete(ctx, apiClient.Workflows, "91cc8988-2223-404a-a3f5-5f1a839ecd45")
-		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 		assert.Equal(t, 1, server.Calls())
-		assert.Nil(t, err)
+		assert.Zero(t, resp)
+		var apiError api.APIError
+		assert.ErrorAs(t, err, &apiError)
+		assert.Equal(t, http.StatusNotFound, apiError.StatusCode)
 	})
 }
 
@@ -793,9 +807,10 @@ func TestAutomationClient_List(t *testing.T) {
 		client := automation.NewClient(rest.NewClient(server.URL(), server.Client()))
 		ctx := testutils.ContextWithLogger(t)
 		resp, err := client.List(ctx, apiClient.Workflows)
-		assert.Len(t, resp, 1)
-		assert.Len(t, resp[0].Objects, 0)
-		assert.Nil(t, err)
+		assert.Len(t, resp, 0)
+		var apiError api.APIError
+		assert.ErrorAs(t, err, &apiError)
+		assert.Equal(t, http.StatusInternalServerError, apiError.StatusCode)
 	})
 
 	t.Run("List - API Call returned with != 2xx", func(t *testing.T) {
@@ -816,10 +831,10 @@ func TestAutomationClient_List(t *testing.T) {
 		client := automation.NewClient(rest.NewClient(server.URL(), server.Client()))
 		ctx := testutils.ContextWithLogger(t)
 		resp, err := client.List(ctx, apiClient.Workflows)
-		assert.Len(t, resp, 1)
-		assert.Equal(t, resp[0].Response.StatusCode, http.StatusBadRequest)
-		assert.Len(t, resp[0].Objects, 0)
-		assert.Nil(t, err)
+		var apiError api.APIError
+		assert.Len(t, resp, 0)
+		assert.ErrorAs(t, err, &apiError)
+		assert.Equal(t, http.StatusBadRequest, apiError.StatusCode)
 	})
 
 	t.Run("List - API Call failed", func(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code-core/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
To align this client with the newly created document client (https://github.com/Dynatrace/dynatrace-configuration-as-code-core/pull/91), this PR changes the way the client behaves in error cases.  

Instead of always returning a response, it now returns an `APIError`error type in case the API request resulted in a HTTP error status != 2xx.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
