### PR TITLE
chore: Update bucket client to return API errors

### DIFF
--- a/api/response.go
+++ b/api/response.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
+	"net/http"
 )
 
 // Response represents an API response
@@ -25,6 +26,15 @@ type Response struct {
 	StatusCode int              `json:"-"`
 	Data       []byte           `json:"-"`
 	Request    rest.RequestInfo `json:"-"`
+}
+
+func NewResponseFromHTTPResponseAndBody(resp *http.Response, body []byte) Response {
+	return Response{
+		StatusCode: resp.StatusCode,
+		Data:       body,
+		Request: rest.RequestInfo{
+			Method: resp.Request.Method,
+			URL:    resp.Request.URL.String()}}
 }
 
 // PagedListResponse is a list of ListResponse values.
@@ -125,6 +135,14 @@ type APIError struct {
 	StatusCode int              `json:"statusCode"` // StatusCode is the HTTP response status code returned by the API.
 	Body       []byte           `json:"body"`       // Body is the HTTP payload returned by the API.
 	Request    rest.RequestInfo `json:"request"`    // Request is information about the original request that led to this response error.
+}
+
+func NewAPIErrorFromResponseAndBody(resp *http.Response, body []byte) APIError {
+	return APIError{
+		StatusCode: resp.StatusCode,
+		Body:       body,
+		Request:    rest.RequestInfo{Method: resp.Request.Method, URL: resp.Request.URL.String()},
+	}
 }
 
 // Error returns a string representation of the APIError, providing details about the failed API request.

--- a/clients/buckets/bucket.go
+++ b/clients/buckets/bucket.go
@@ -21,14 +21,13 @@ import (
 	"fmt"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 	bucketAPI "github.com/dynatrace/dynatrace-configuration-as-code-core/api/clients/buckets"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
+	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	"io"
 	"net/http"
 	"strconv"
 	"time"
-
-	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
-	"github.com/go-logr/logr"
 )
 
 const (
@@ -139,7 +138,12 @@ func (c Client) Get(ctx context.Context, bucketName string) (Response, error) {
 	if err != nil {
 		return Response{}, err
 	}
-	return api.Response{StatusCode: resp.StatusCode, Data: body, Request: rest.RequestInfo{Method: resp.Request.Method, URL: resp.Request.URL.String()}}, nil
+
+	if !rest.IsSuccess(resp) {
+		return Response{}, api.NewAPIErrorFromResponseAndBody(resp, body)
+	}
+
+	return api.NewResponseFromHTTPResponseAndBody(resp, body), nil
 }
 
 // List retrieves all bucket definitions. The function sends a GET request
@@ -161,6 +165,18 @@ func (c Client) List(ctx context.Context) (ListResponse, error) {
 	if err != nil {
 		return ListResponse{}, fmt.Errorf("failed to list buckets:%w", err)
 	}
+
+	// if the response has code != 2xx return empty list with response info
+	if !rest.IsSuccess(resp) {
+		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			return ListResponse{}, err
+		}
+
+		return ListResponse{}, api.NewAPIErrorFromResponseAndBody(resp, body)
+	}
+
 	l, err := unmarshalJSONList(resp)
 	if err != nil {
 		return ListResponse{}, fmt.Errorf("failed to parse list response:%w", err)
@@ -207,11 +223,11 @@ func (c Client) Create(ctx context.Context, bucketName string, data []byte) (Res
 		return Response{}, err
 	}
 
-	return api.Response{
-		StatusCode: resp.StatusCode,
-		Data:       body,
-		Request:    rest.RequestInfo{Method: resp.Request.Method, URL: resp.Request.URL.String()},
-	}, nil
+	if !rest.IsSuccess(resp) {
+		return Response{}, api.NewAPIErrorFromResponseAndBody(resp, body)
+	}
+
+	return api.NewResponseFromHTTPResponseAndBody(resp, body), nil
 }
 
 var DeletingBucketErr = errors.New("cannot update bucket that is currently being deleted")
@@ -258,14 +274,8 @@ func (c Client) Update(ctx context.Context, bucketName string, data []byte) (Res
 		if err != nil {
 			return Response{}, err
 		}
-		r := api.Response{
-			StatusCode: resp.StatusCode,
-			Data:       body,
-			Request: rest.RequestInfo{
-				Method: "GET",
-			},
-		}
-		return r, nil
+
+		return api.Response{}, api.NewAPIErrorFromResponseAndBody(resp, body)
 	}
 
 	current, err := unmarshalJSON(resp)
@@ -304,11 +314,19 @@ func (c Client) Update(ctx context.Context, bucketName string, data []byte) (Res
 		return api.Response{}, err
 	}
 
-	if rest.IsSuccess(resp) {
-		logger.Info(fmt.Sprintf("Updated bucket with bucket name %q", bucketName))
+	if !rest.IsSuccess(resp) {
+		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			return Response{}, err
+		}
+
+		return api.Response{}, api.NewAPIErrorFromResponseAndBody(resp, body)
 	}
 
-	return api.Response{StatusCode: resp.StatusCode, Data: body, Request: rest.RequestInfo{Method: resp.Request.Method, URL: resp.Request.URL.String()}}, nil
+	logger.Info(fmt.Sprintf("Updated bucket with bucket name %q", bucketName))
+
+	return api.NewResponseFromHTTPResponseAndBody(resp, body), nil
 }
 
 // Upsert creates or updates a bucket definition using the provided apiClient. The function first attempts
@@ -365,7 +383,7 @@ func (c Client) Delete(ctx context.Context, bucketName string) (Response, error)
 	}
 
 	if !rest.IsSuccess(resp) {
-		return api.Response{StatusCode: resp.StatusCode, Data: body, Request: rest.RequestInfo{Method: resp.Request.Method, URL: resp.Request.URL.String()}}, nil
+		return api.Response{}, api.NewAPIErrorFromResponseAndBody(resp, body)
 	}
 
 	// await bucket being successfully deleted
@@ -376,7 +394,7 @@ func (c Client) Delete(ctx context.Context, bucketName string) (Response, error)
 		return api.Response{}, fmt.Errorf("unable to delete object with bucket name %q: %w", bucketName, err)
 	}
 
-	return api.Response{StatusCode: resp.StatusCode, Data: body, Request: rest.RequestInfo{Method: resp.Request.Method, URL: resp.Request.URL.String()}}, nil
+	return api.NewResponseFromHTTPResponseAndBody(resp, body), nil
 }
 
 // upsert is an internal function used by Upsert to perform the create or update logic.
@@ -401,12 +419,12 @@ func (c Client) upsert(ctx context.Context, bucketName string, data []byte) (Res
 	// If creating the bucket definition worked, return the result
 	if rest.IsSuccess(resp) {
 		logger.Info(fmt.Sprintf("Created bucket with bucket name %q", bucketName))
-		return api.Response{StatusCode: resp.StatusCode, Data: body, Request: rest.RequestInfo{Method: resp.Request.Method, URL: resp.Request.URL.String()}}, nil
+		return api.NewResponseFromHTTPResponseAndBody(resp, body), nil
 	}
 
 	// Return if creation failed, but the errors was not 409 Conflict - Bucket already exists
 	if resp.StatusCode != http.StatusConflict {
-		return api.Response{StatusCode: resp.StatusCode, Data: body, Request: rest.RequestInfo{Method: resp.Request.Method, URL: resp.Request.URL.String()}}, err
+		return api.Response{}, api.NewAPIErrorFromResponseAndBody(resp, body)
 	}
 
 	// If bucket is currently being deleted, wait for it to be gone, then re-create it
@@ -434,7 +452,7 @@ func (c Client) upsert(ctx context.Context, bucketName string, data []byte) (Res
 
 func (c Client) create(ctx context.Context, bucketName string, data []byte) (*http.Response, error) {
 	if err := setBucketName(bucketName, &data); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to set bucket name: %w", err)
 	}
 	r, err := c.apiClient.Create(ctx, data)
 	if err != nil {
@@ -521,7 +539,7 @@ func (c Client) getAndUpdate(ctx context.Context, bucketName string, data []byte
 	var m map[string]interface{}
 	err = json.Unmarshal(data, &m)
 	if err != nil {
-		return nil, fmt.Errorf("unable to unmarshal template: %w", err)
+		return nil, fmt.Errorf("unable to unmarshal data: %w", err)
 	}
 	m["bucketName"] = res.BucketName
 	m["version"] = res.Version
@@ -571,12 +589,12 @@ func setBucketName(bucketName string, data *[]byte) error {
 	var m map[string]interface{}
 	err := json.Unmarshal(*data, &m)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to unmarshal data: %w", err)
 	}
 	m["bucketName"] = bucketName
 	*data, err = json.Marshal(m)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to marshal data: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
**What this PR does / Why we need it:**
To align this client with the newly created document client (https://github.com/Dynatrace/dynatrace-configuration-as-code-core/pull/91), this PR changes the way the bucket client behaves in error cases.

Instead of always returning a response, it now returns an `APIErrorerror` type in case the API request resulted in a HTTP error status != 2xx.

Errors that occur during reading the body currently do not include a status code, however this is something we may address in a follow-up ticket.