### PR TITLE
feat: Allow client factory to create REST clients

### DIFF
--- a/api/response.go
+++ b/api/response.go
@@ -194,6 +194,14 @@ func (r APIError) Error() string {
 	return fmt.Sprintf("API request HTTP %s %s failed with status code %d: %s", r.Request.Method, r.Request.URL, r.StatusCode, string(r.Body))
 }
 
+func (r APIError) Is4xxError() bool {
+	return r.StatusCode >= 400 && r.StatusCode <= 499
+}
+
+func (r APIError) Is5xxError() bool {
+	return r.StatusCode >= 500 && r.StatusCode <= 599
+}
+
 // DecodeJSON tries to unmarshal the Response.Data of the given Response r into an object of T.
 func DecodeJSON[T any](r Response) (T, error) {
 	var t T

--- a/api/response.go
+++ b/api/response.go
@@ -144,7 +144,7 @@ func NewAPIErrorFromResponseAndBody(resp *http.Response, body []byte) APIError {
 	return APIError{
 		StatusCode: resp.StatusCode,
 		Body:       body,
-		Request:    rest.RequestInfo{Method: resp.Request.Method, URL: resp.Request.URL.String()},
+		Request:    rest.NewRequestInfoFromResponse(resp.Request),
 	}
 }
 

--- a/api/response.go
+++ b/api/response.go
@@ -48,22 +48,27 @@ func AsResponseOrError(resp *http.Response, err error) (*Response, error) {
 		return nil, NewAPIErrorFromResponseAndBody(resp, responseBody)
 	}
 
-	return &Response{
-		StatusCode: resp.StatusCode,
-		Header:     resp.Header,
-		Data:       responseBody,
-		Request: rest.RequestInfo{
-			Method: resp.Request.Method,
-			URL:    resp.Request.URL.String()}}, nil
+	response := NewResponseFromHTTPResponseAndBody(resp, responseBody)
+	return &response, nil
 }
 
 func NewResponseFromHTTPResponseAndBody(resp *http.Response, body []byte) Response {
 	return Response{
 		StatusCode: resp.StatusCode,
 		Data:       body,
-		Request: rest.RequestInfo{
-			Method: resp.Request.Method,
-			URL:    resp.Request.URL.String()}}
+		Request:    NewRequestInfoFromRequest(resp.Request),
+	}
+}
+
+func NewRequestInfoFromRequest(request *http.Request) rest.RequestInfo {
+	var method, url string
+	if request != nil {
+		method = request.Method
+		if request.URL != nil {
+			url = request.URL.String()
+		}
+	}
+	return rest.RequestInfo{Method: method, URL: url}
 }
 
 // PagedListResponse is a list of ListResponse values.
@@ -170,7 +175,7 @@ func NewAPIErrorFromResponseAndBody(resp *http.Response, body []byte) APIError {
 	return APIError{
 		StatusCode: resp.StatusCode,
 		Body:       body,
-		Request:    rest.NewRequestInfoFromResponse(resp.Request),
+		Request:    NewRequestInfoFromRequest(resp.Request),
 	}
 }
 

--- a/api/response.go
+++ b/api/response.go
@@ -26,7 +26,8 @@ import (
 
 // Response represents an API response
 type Response struct {
-	StatusCode int              `json:"-"`
+	StatusCode int `json:"-"`
+	Header     http.Header
 	Data       []byte           `json:"-"`
 	Request    rest.RequestInfo `json:"-"`
 }
@@ -49,6 +50,7 @@ func AsResponseOrError(resp *http.Response, err error) (*Response, error) {
 
 	return &Response{
 		StatusCode: resp.StatusCode,
+		Header:     resp.Header,
 		Data:       responseBody,
 		Request: rest.RequestInfo{
 			Method: resp.Request.Method,

--- a/api/rest/client.go
+++ b/api/rest/client.go
@@ -151,7 +151,7 @@ func (c *Client) SetHeader(key, value string) {
 	c.headers[key] = value
 }
 
-// BaseURL returns the base url configured fpr this client
+// BaseURL returns the base url configured for this client
 func (c *Client) BaseURL() *url.URL {
 	return c.baseURL
 }

--- a/api/rest/response.go
+++ b/api/rest/response.go
@@ -22,17 +22,6 @@ type RequestInfo struct {
 	URL    string `json:"url"`    // The full URL of the request
 }
 
-func NewRequestInfoFromResponse(request *http.Request) RequestInfo {
-	var method, url string
-	if request != nil {
-		method = request.Method
-		if request.URL != nil {
-			url = request.URL.String()
-		}
-	}
-	return RequestInfo{Method: method, URL: url}
-}
-
 func IsSuccess(resp *http.Response) bool {
 	return resp.StatusCode >= 200 && resp.StatusCode <= 299
 }

--- a/api/rest/response.go
+++ b/api/rest/response.go
@@ -22,6 +22,17 @@ type RequestInfo struct {
 	URL    string `json:"url"`    // The full URL of the request
 }
 
+func NewRequestInfoFromResponse(request *http.Request) RequestInfo {
+	var method, url string
+	if request != nil {
+		method = request.Method
+		if request.URL != nil {
+			url = request.URL.String()
+		}
+	}
+	return RequestInfo{Method: method, URL: url}
+}
+
 func IsSuccess(resp *http.Response) bool {
 	return resp.StatusCode >= 200 && resp.StatusCode <= 299
 }


### PR DESCRIPTION
This PR extends the clients factory with the ability to create REST clients directly, but more importantly, clients that can target classic APIs (with access token). It also adapts the creation of accounts clients to be more consistent.

It also adds a helper function `AsResponseOrError(...)`,  which should be used to consistently read and close the response body and allow for easier error handling.

Calling this returns EITHER a `Response` with the read body and a successful status OR an error, which could be an `APIError` if a response was actually received. This can simplify e.g. error handling for skipping 404s during deletion to something like:
```
_, err = coreapi.AsResponseOrError(d.classicClient.DELETE(ctx, parsedURL.String(), corerest.RequestOptions{}))
	if err != nil {
		apiError := coreapi.APIError{}
		if errors.As(err, &apiError) && apiError.StatusCode == http.StatusNotFound {
			log.Debug("No config with id '%s' found to delete (HTTP 404 response)", id)
			return nil
		}
		return err
	}
```
