### PR TITLE
feat: Add rate limiter and request retrier to factory

### DIFF
--- a/api/response.go
+++ b/api/response.go
@@ -61,6 +61,7 @@ func AsResponseOrError(resp *http.Response, err error) (*Response, error) {
 
 func NewResponseFromHTTPResponseAndBody(resp *http.Response, body []byte) Response {
 	return Response{
+		Header:     resp.Header,
 		StatusCode: resp.StatusCode,
 		Data:       body,
 		Request:    NewRequestInfoFromRequest(resp.Request),

--- a/api/rest/client_test.go
+++ b/api/rest/client_test.go
@@ -447,7 +447,7 @@ func TestClient_WithRateLimiting(t *testing.T) {
 		{
 			name:             "missing reset time header results in default timeout",
 			givenHeaders:     map[string]string{},
-			wantBlockingTime: 1 * time.Second,
+			wantBlockingTime: 10 * time.Second,
 		},
 	}
 

--- a/api/rest/rate.go
+++ b/api/rest/rate.go
@@ -89,8 +89,7 @@ func (rl *RateLimiter) Update(ctx context.Context, status int, headers http.Head
 
 	reset, err := extractTimeout(headers)
 	if err != nil {
-		logger.V(1).Info(fmt.Sprintf("Received 429 TooManyRequests HTTP response but no rate limit header. Using default timeout of %s", defaultTimeout), "timeout", defaultTimeout)
-
+		logger.V(1).Info(fmt.Sprintf("Received 429 TooManyRequests HTTP response but using default timeout of %s because could not extract one: %s", defaultTimeout, err.Error()), "timeout", defaultTimeout, "headers", headers)
 		rt := defaultTimeout
 		rl.resetTimeout = &rt
 		ra := rl.Clock.Now().Add(defaultTimeout)

--- a/api/rest/rate.go
+++ b/api/rest/rate.go
@@ -30,7 +30,7 @@ const (
 	limitHeader = "X-RateLimit-Limit"
 	resetHeader = "X-RateLimit-Reset"
 
-	defaultTimeout = time.Second
+	defaultTimeout = time.Second * 10
 )
 
 type RateLimiter struct {

--- a/clients/factory.go
+++ b/clients/factory.go
@@ -61,7 +61,8 @@ type factory struct {
 	userAgent              string                    // The User-Agent header to be set
 	httpListener           *rest.HTTPListener        // The HTTP listener to be set
 	concurrentRequestLimit int                       // The number of allowed concurrent requests
-	rateLimiterEnabled     bool                      // Enables rate limiter for clients.
+	rateLimiterEnabled     bool                      // Enables rate limiter for clients
+	requestRetrier         *rest.RequestRetrier      // The retry strategy
 }
 
 // WithOAuthCredentials sets the OAuth2 client credentials configuration for the factory.
@@ -107,8 +108,8 @@ func (f factory) WithHTTPListener(listener *rest.HTTPListener) factory {
 	return f
 }
 
-// WithConcurrentRequestLimit sets the given request limit that specifying how much
-// requests can be triggered concurrently by the underlying rest/http client
+// WithConcurrentRequestLimit sets the given request limit that specifies how many
+// requests can be triggered concurrently by the underlying rest/http client.
 func (f factory) WithConcurrentRequestLimit(limit int) factory {
 	f.concurrentRequestLimit = limit
 	return f
@@ -117,6 +118,12 @@ func (f factory) WithConcurrentRequestLimit(limit int) factory {
 // WithRateLimiter enables a RateLimiter for Clients.
 func (f factory) WithRateLimiter(enabled bool) factory {
 	f.rateLimiterEnabled = enabled
+	return f
+}
+
+// WithRequestRetrier sets the RequestRetrier for the underlying rest/http client.
+func (f factory) WithRequestRetrier(requestRetrier *rest.RequestRetrier) factory {
+	f.requestRetrier = requestRetrier
 	return f
 }
 
@@ -222,6 +229,10 @@ func (f factory) createRestClient(u string, httpClient *http.Client) (*rest.Clie
 	opts := []rest.Option{rest.WithHTTPListener(f.httpListener)}
 	if f.rateLimiterEnabled {
 		opts = append(opts, rest.WithRateLimiter())
+	}
+
+	if f.requestRetrier != nil {
+		opts = append(opts, rest.WithRequestRetrier(f.requestRetrier))
 	}
 
 	restClient := rest.NewClient(parsedURL, httpClient, opts...)


### PR DESCRIPTION
This PR:
- fixes issue where headers were not being copied into responses, 
- exposes the rate limiter and request retrier to consumers of `client.Factory`, and
- changes the default rate-limit timeout to 10 seconds