### PR TITLE
chore: Use minimal default timeout in rate limiter

### DIFF
--- a/api/rest/client_test.go
+++ b/api/rest/client_test.go
@@ -447,7 +447,7 @@ func TestClient_WithRateLimiting(t *testing.T) {
 		{
 			name:             "missing reset time header results in default timeout",
 			givenHeaders:     map[string]string{},
-			wantBlockingTime: 10 * time.Second,
+			wantBlockingTime: 100 * time.Millisecond,
 		},
 	}
 

--- a/api/rest/rate.go
+++ b/api/rest/rate.go
@@ -30,7 +30,7 @@ const (
 	limitHeader = "X-RateLimit-Limit"
 	resetHeader = "X-RateLimit-Reset"
 
-	defaultTimeout = time.Second * 10
+	defaultTimeout = time.Millisecond * 100
 )
 
 type RateLimiter struct {


### PR DESCRIPTION
This PR reduces the default timeout in rate limiter to 100 ms.

