### PR TITLE
feat: Support per call retry settings

### DIFF
--- a/api/rest/client.go
+++ b/api/rest/client.go
@@ -236,8 +236,8 @@ func (c *Client) sendWithRetries(ctx context.Context, req *http.Request, retryCo
 
 	if requestRetrier != nil && retryCount < requestRetrier.MaxRetries &&
 		requestRetrier.ShouldRetryFunc != nil && requestRetrier.ShouldRetryFunc(response) {
-		logger.V(1).Info(fmt.Sprintf("Retrying failed request %q (HTTP %s) after %d ms delay... (try %d/%d)", req.URL, response.Status, 100, retryCount+1, requestRetrier.MaxRetries), "statusCode", response.StatusCode, "try", retryCount+1, "maxRetries", requestRetrier.MaxRetries)
-		time.Sleep(100 * time.Millisecond)
+		logger.V(1).Info(fmt.Sprintf("Retrying failed request %q (HTTP %s) after %d ms delay... (try %d/%d)", req.URL, response.Status, requestRetrier.DelayAfterRetry.Milliseconds(), retryCount+1, requestRetrier.MaxRetries), "statusCode", response.StatusCode, "try", retryCount+1, "maxRetries", requestRetrier.MaxRetries)
+		time.Sleep(requestRetrier.DelayAfterRetry)
 		return c.sendWithRetries(ctx, req, retryCount+1, options)
 	}
 	return response, nil

--- a/api/rest/retry.go
+++ b/api/rest/retry.go
@@ -14,10 +14,14 @@
 
 package rest
 
-import "net/http"
+import (
+	"net/http"
+	"time"
+)
 
 // RequestRetrier represents a component for retrying failed HTTP requests.
 type RequestRetrier struct {
+	DelayAfterRetry time.Duration
 	MaxRetries      int
 	ShouldRetryFunc func(resp *http.Response) bool
 }


### PR DESCRIPTION
This PR adds an optional `*RequestRetrier` to `RequestOptions`, allowing per call retry settings to be specified which override the general ones for the client.

In addition, `DelayAfterRetry` is added to `RequestRetrier`, allowing the delay between attempts to also be varied for each call or the client the general.