### PR TITLE
feat: Simplify overriding retry behavior of REST client

### DIFF
--- a/api/clients/buckets/bucket.go
+++ b/api/clients/buckets/bucket.go
@@ -61,7 +61,7 @@ func NewClient(client *rest.Client) *Client {
 //   - Response: A Response containing the result of the HTTP call, including status code and data.
 //   - error: An error if the HTTP call fails or another error happened.
 func (c Client) Create(ctx context.Context, data []byte) (*http.Response, error) {
-	r, err := c.client.POST(ctx, endpointPath, bytes.NewReader(data), rest.RequestOptions{})
+	r, err := c.client.POST(ctx, endpointPath, bytes.NewReader(data), rest.RequestOptions{CustomShouldRetryFunc: rest.RetryIfTooManyRequests})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create new bucket: %w", err)
 	}
@@ -83,7 +83,7 @@ func (c Client) Get(ctx context.Context, bucketName string) (*http.Response, err
 	if err != nil {
 		return nil, fmt.Errorf("failed to create URL: %w", err)
 	}
-	return c.client.GET(ctx, path, rest.RequestOptions{})
+	return c.client.GET(ctx, path, rest.RequestOptions{CustomShouldRetryFunc: rest.RetryIfTooManyRequests})
 }
 
 // List all buckets, by making a HTTP GET request against the API.
@@ -95,7 +95,7 @@ func (c Client) Get(ctx context.Context, bucketName string) (*http.Response, err
 //   - Response: A Response containing the result of the HTTP call, including status code and data.
 //   - error: An error if the HTTP call fails or another error happened.
 func (c Client) List(ctx context.Context) (*http.Response, error) {
-	return c.client.GET(ctx, endpointPath, rest.RequestOptions{})
+	return c.client.GET(ctx, endpointPath, rest.RequestOptions{CustomShouldRetryFunc: rest.RetryIfTooManyRequests})
 }
 
 // Update a bucket by name, by making a HTTP PUT /<bucketName> request against the API.
@@ -116,7 +116,8 @@ func (c Client) Update(ctx context.Context, bucketName string, bucketVersion str
 	}
 
 	return c.client.PUT(ctx, path, bytes.NewReader(data), rest.RequestOptions{
-		QueryParams: url.Values{"optimistic-locking-version": []string{bucketVersion}},
+		QueryParams:           url.Values{"optimistic-locking-version": []string{bucketVersion}},
+		CustomShouldRetryFunc: rest.RetryIfTooManyRequests,
 	})
 }
 
@@ -137,5 +138,5 @@ func (c Client) Delete(ctx context.Context, bucketName string) (*http.Response, 
 	if err != nil {
 		return nil, fmt.Errorf("failed to create URL: %w", err)
 	}
-	return c.client.DELETE(ctx, path, rest.RequestOptions{})
+	return c.client.DELETE(ctx, path, rest.RequestOptions{CustomShouldRetryFunc: rest.RetryIfTooManyRequests})
 }

--- a/api/clients/documents/documents.go
+++ b/api/clients/documents/documents.go
@@ -138,7 +138,8 @@ func (c *Client) Delete(ctx context.Context, id string, version int) (*http.Resp
 	}
 
 	resp, err := c.client.DELETE(ctx, path, rest.RequestOptions{
-		QueryParams: map[string][]string{optimisticLockingHeader: {strconv.Itoa(version)}},
+		QueryParams:           map[string][]string{optimisticLockingHeader: {strconv.Itoa(version)}},
+		CustomShouldRetryFunc: rest.RetryOnFailureExcept404,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("unable to delete object: %w", err)

--- a/api/rest/client.go
+++ b/api/rest/client.go
@@ -40,7 +40,7 @@ type RequestOptions struct {
 	ContentType string
 
 	// CustomShouldRetryFunc optionally overrides the ShouldRetryFunc of
-	// the RequestRetrier specified for the client.
+	// the RetryOptions specified for the client.
 	CustomShouldRetryFunc RetryFunc
 }
 
@@ -61,10 +61,10 @@ func WithTimeout(timeout time.Duration) Option {
 	}
 }
 
-// WithRequestRetrier sets the RequestRetrier for the Client.
-func WithRequestRetrier(retrier *RequestRetrier) Option {
+// WithRetryOptions sets the RetryOptions for the Client.
+func WithRetryOptions(opts *RetryOptions) Option {
 	return func(c *Client) {
-		c.requestRetrier = retrier
+		c.retryOptions = opts
 	}
 }
 
@@ -80,7 +80,7 @@ func WithHTTPListener(listener *HTTPListener) Option {
 // reached. If the server should not reply with an X-RateLimit-Reset header, a default delay is enforced.
 // Note that a Client with RateLimiter will not automatically retry an API call after a limit was hit, but return the
 // Too Many Requests 429 Response to you.
-// If wish for the Client to retry on errors configure a RequestRetrier as well.
+// If the Client should retry on errors, configure RetryOptions as well.
 func WithRateLimiter() Option {
 	return func(c *Client) {
 		c.rateLimiter = NewRateLimiter()
@@ -95,7 +95,7 @@ type Client struct {
 
 	concurrentRequestLimiter *ConcurrentRequestLimiter // Concurrent request limiter component (optional)
 	timeout                  time.Duration             // Request timeout (optional)
-	requestRetrier           *RequestRetrier           // HTTP request retrier component (optional)
+	retryOptions             *RetryOptions             // Retry options (optional)
 	httpListener             *HTTPListener             // HTTP listener component (optional)
 	rateLimiter              *RateLimiter              // Rate limiter component (optional)
 }
@@ -229,16 +229,16 @@ func (c *Client) sendWithRetries(ctx context.Context, req *http.Request, retryCo
 		c.rateLimiter.Update(ctx, response.StatusCode, response.Header)
 	}
 
-	if c.requestRetrier != nil && retryCount < c.requestRetrier.MaxRetries {
+	if c.retryOptions != nil && retryCount < c.retryOptions.MaxRetries {
 
-		shouldRetryFunc := c.requestRetrier.ShouldRetryFunc
+		shouldRetryFunc := c.retryOptions.ShouldRetryFunc
 		if options.CustomShouldRetryFunc != nil {
 			shouldRetryFunc = options.CustomShouldRetryFunc
 		}
 
 		if (shouldRetryFunc != nil) && shouldRetryFunc(response) {
-			logger.V(1).Info(fmt.Sprintf("Retrying failed request %q (HTTP %s) after %d ms delay... (try %d/%d)", req.URL, response.Status, c.requestRetrier.DelayAfterRetry.Milliseconds(), retryCount+1, c.requestRetrier.MaxRetries), "statusCode", response.StatusCode, "try", retryCount+1, "maxRetries", c.requestRetrier.MaxRetries)
-			time.Sleep(c.requestRetrier.DelayAfterRetry)
+			logger.V(1).Info(fmt.Sprintf("Retrying failed request %q (HTTP %s) after %d ms delay... (try %d/%d)", req.URL, response.Status, c.retryOptions.DelayAfterRetry.Milliseconds(), retryCount+1, c.retryOptions.MaxRetries), "statusCode", response.StatusCode, "try", retryCount+1, "maxRetries", c.retryOptions.MaxRetries)
+			time.Sleep(c.retryOptions.DelayAfterRetry)
 			return c.sendWithRetries(ctx, req, retryCount+1, options)
 		}
 	}

--- a/api/rest/client_test.go
+++ b/api/rest/client_test.go
@@ -702,16 +702,11 @@ func TestClient_RequestOptionsCustomRetrier(t *testing.T) {
 	defer server.Close()
 
 	baseURL, _ := url.Parse(server.URL)
-	client := NewClient(baseURL, server.Client())
+	client := NewClient(baseURL, server.Client(), WithRequestRetrier(&RequestRetrier{MaxRetries: 1, ShouldRetryFunc: func(resp *http.Response) bool { return false }}))
 
 	ctx := testutils.ContextWithLogger(t)
 
-	resp, err := client.GET(ctx, "", RequestOptions{CustomRetrier: &RequestRetrier{
-		MaxRetries: 1,
-		ShouldRetryFunc: func(resp *http.Response) bool {
-			return resp.StatusCode != http.StatusOK
-		},
-	}})
+	resp, err := client.GET(ctx, "", RequestOptions{CustomShouldRetryFunc: func(resp *http.Response) bool { return resp.StatusCode != http.StatusOK }})
 	if err != nil {
 		t.Fatalf("failed to send GET request: %v", err)
 	}

--- a/api/rest/client_test.go
+++ b/api/rest/client_test.go
@@ -45,10 +45,10 @@ func TestNewClient(t *testing.T) {
 	client = NewClient(baseURL, customHTTPClient)
 	assert.Equal(t, customHTTPClient, client.httpClient, "Expected custom HTTP client to be set")
 
-	// Test WithRequestRetrier
-	retrier := &RequestRetrier{}
-	client = NewClient(baseURL, nil, WithRequestRetrier(retrier))
-	assert.Equal(t, retrier, client.requestRetrier, "Expected RequestRetrier to be set")
+	// Test WithRetryOptions
+	opts := &RetryOptions{}
+	client = NewClient(baseURL, nil, WithRetryOptions(opts))
+	assert.Equal(t, opts, client.retryOptions, "Expected RetryOptions to be set")
 }
 
 func TestClient_CRUD(t *testing.T) {
@@ -310,7 +310,7 @@ func TestClient_WithRetries(t *testing.T) {
 	defer server.Close()
 
 	baseURL, _ := url.Parse(server.URL)
-	client := NewClient(baseURL, nil, WithRequestRetrier(&RequestRetrier{
+	client := NewClient(baseURL, nil, WithRetryOptions(&RetryOptions{
 		MaxRetries: 1,
 		ShouldRetryFunc: func(resp *http.Response) bool {
 			return resp.StatusCode != http.StatusOK
@@ -653,7 +653,7 @@ func TestClient_WithRetriesAndRateLimit(t *testing.T) {
 
 	baseURL, _ := url.Parse(server.URL)
 	client := NewClient(baseURL, nil,
-		WithRequestRetrier(&RequestRetrier{
+		WithRetryOptions(&RetryOptions{
 			MaxRetries:      5,
 			ShouldRetryFunc: RetryIfNotSuccess,
 		}),
@@ -689,7 +689,7 @@ func TestClient_RequestOptionsQueryParams(t *testing.T) {
 	client.GET(ctx, "", RequestOptions{QueryParams: expectedQueryParams})
 }
 
-func TestClient_RequestOptionsCustomRetrier(t *testing.T) {
+func TestClient_RequestOptionsCustomShouldRetryFunc(t *testing.T) {
 	apiHits := 0
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		if apiHits == 0 {
@@ -702,7 +702,7 @@ func TestClient_RequestOptionsCustomRetrier(t *testing.T) {
 	defer server.Close()
 
 	baseURL, _ := url.Parse(server.URL)
-	client := NewClient(baseURL, server.Client(), WithRequestRetrier(&RequestRetrier{MaxRetries: 1, ShouldRetryFunc: func(resp *http.Response) bool { return false }}))
+	client := NewClient(baseURL, server.Client(), WithRetryOptions(&RetryOptions{MaxRetries: 1, ShouldRetryFunc: func(resp *http.Response) bool { return false }}))
 
 	ctx := testutils.ContextWithLogger(t)
 

--- a/api/rest/retry.go
+++ b/api/rest/retry.go
@@ -33,8 +33,8 @@ func RetryIfNotSuccess(resp *http.Response) bool {
 	return !(resp.StatusCode >= 200 && resp.StatusCode <= 299)
 }
 
-// RetryIfStatusTooManyRequests return true for responses with status code Too Many Requests (429).
-func RetryIfStatusTooManyRequests(resp *http.Response) bool {
+// RetryIfTooManyRequests return true for responses with status code Too Many Requests (429).
+func RetryIfTooManyRequests(resp *http.Response) bool {
 	return resp.StatusCode == http.StatusTooManyRequests
 }
 

--- a/api/rest/retry.go
+++ b/api/rest/retry.go
@@ -21,14 +21,14 @@ import (
 
 type RetryFunc func(resp *http.Response) bool
 
-// RequestRetrier represents a component for retrying failed HTTP requests.
-type RequestRetrier struct {
+// RetryOptions represents a component for retrying failed HTTP requests.
+type RetryOptions struct {
 	DelayAfterRetry time.Duration
 	MaxRetries      int
 	ShouldRetryFunc RetryFunc
 }
 
-// RetryIfNotSuccess implements a basic retry function for a RequestRetrier which will retry on any non 2xx status code.
+// RetryIfNotSuccess is a basic retry function which will retry on any non 2xx status code.
 func RetryIfNotSuccess(resp *http.Response) bool {
 	return !(resp.StatusCode >= 200 && resp.StatusCode <= 299)
 }

--- a/clients/factory.go
+++ b/clients/factory.go
@@ -62,7 +62,7 @@ type factory struct {
 	httpListener           *rest.HTTPListener        // The HTTP listener to be set
 	concurrentRequestLimit int                       // The number of allowed concurrent requests
 	rateLimiterEnabled     bool                      // Enables rate limiter for clients
-	requestRetrier         *rest.RequestRetrier      // The retry strategy
+	retryOptions           *rest.RetryOptions        // The retry strategy
 }
 
 // WithOAuthCredentials sets the OAuth2 client credentials configuration for the factory.
@@ -121,9 +121,9 @@ func (f factory) WithRateLimiter(enabled bool) factory {
 	return f
 }
 
-// WithRequestRetrier sets the RequestRetrier for the underlying rest/http client.
-func (f factory) WithRequestRetrier(requestRetrier *rest.RequestRetrier) factory {
-	f.requestRetrier = requestRetrier
+// WithRetryOptions sets the RetryOptions for the underlying rest/http clients.
+func (f factory) WithRetryOptions(retryOptions *rest.RetryOptions) factory {
+	f.retryOptions = retryOptions
 	return f
 }
 
@@ -231,8 +231,8 @@ func (f factory) createRestClient(u string, httpClient *http.Client) (*rest.Clie
 		opts = append(opts, rest.WithRateLimiter())
 	}
 
-	if f.requestRetrier != nil {
-		opts = append(opts, rest.WithRequestRetrier(f.requestRetrier))
+	if f.retryOptions != nil {
+		opts = append(opts, rest.WithRetryOptions(f.retryOptions))
 	}
 
 	restClient := rest.NewClient(parsedURL, httpClient, opts...)


### PR DESCRIPTION
This PR simplifies overriding retry behavior to just providing the "should retry function" rather than the whole RequestRetrier structure. This is useful because it makes it easy to change the retry behavior without knowledge of the delay or maximum number of retries.

The PR also adjusts the retry behavior of the clients:
 - essentially turning it off for buckets - this client has its own retry implementation - only retry for `StatusTooManyRequests`
 - for automation client:
   - if doing an "admin access" request, no retrying occurs if `StatusForbidden` is returned,
   - if deleting, no retrying occurs if `StatusNotFound` is returned.
 - for documents client, if deleting, no retrying occurs if `StatusNotFound` is returned
