### PR TITLE
Fix: stop ignore concurrent limit in client factory

### DIFF
--- a/clients/factory.go
+++ b/clients/factory.go
@@ -18,6 +18,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/auth"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/clients/accounts"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
@@ -26,9 +30,6 @@ import (
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/documents"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/openpipeline"
 	"golang.org/x/oauth2/clientcredentials"
-	"net/http"
-	"net/url"
-	"time"
 )
 
 // ErrOAuthCredentialsMissing indicates that no OAuth2 client credentials were provided.
@@ -226,7 +227,10 @@ func (f factory) createRestClient(u string, httpClient *http.Client) (*rest.Clie
 		return nil, fmt.Errorf("failed to parse URL %q: %w", u, err)
 	}
 
-	opts := []rest.Option{rest.WithHTTPListener(f.httpListener)}
+	opts := []rest.Option{
+		rest.WithHTTPListener(f.httpListener),
+		rest.WithConcurrentRequestLimit(f.concurrentRequestLimit),
+	}
 	if f.rateLimiterEnabled {
 		opts = append(opts, rest.WithRateLimiter())
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code-core/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
This change fixes the issue of ignoring the provided concurrent request limit. 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
