### PR TITLE
Fix units used for rate limit headers

### DIFF
--- a/api/rest/rate.go
+++ b/api/rest/rate.go
@@ -94,7 +94,6 @@ func (rl *RateLimiter) Update(ctx context.Context, status int, headers http.Head
 		rl.resetTimeout = &rt
 		ra := rl.Clock.Now().Add(defaultTimeout)
 		rl.resetAt = &ra
-
 		return
 	}
 
@@ -120,13 +119,12 @@ func extractLimit(header http.Header) (rate.Limit, error) {
 // As Dynatrace APIs don't return a time delta, but a Unix timestamp this will return a reset timestamp in server time.
 func extractTimeout(header http.Header) (time.Time, error) {
 	rstr := header.Get(resetHeader)
-	resetMicros, err := strconv.ParseInt(rstr, 10, 64)
+	reset, err := strconv.ParseInt(rstr, 10, 64)
 	if err != nil {
 		return time.Time{}, fmt.Errorf("failed to parse header %q with value %q: %w", resetHeader, rstr, err)
 	}
 
-	reset := time.UnixMicro(resetMicros)
-	return reset, nil
+	return time.Unix(reset, 0), nil
 }
 
 // Wait blocks in case a hard API limit was reached, or the request/second limit was exceeded.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code-core/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
Treat `X-RateLimit-Reset` header values as Seconds. (unix timestamp)
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
