### PR TITLE
fix(OpenPipeline): Set `updateToken`

### DIFF
--- a/clients/openpipeline/openpipeline.go
+++ b/clients/openpipeline/openpipeline.go
@@ -18,11 +18,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+
+	"github.com/go-logr/logr"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/clients/openpipeline"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
-	"github.com/go-logr/logr"
-	"io"
 )
 
 const bodyReadErrMsg = "unable to read API response body"
@@ -125,6 +127,7 @@ func (c Client) Update(ctx context.Context, id string, data []byte) (Response, e
 	}
 
 	d["version"] = m["version"]
+	d["updateToken"] = m["updateToken"]
 	data, err = json.Marshal(d)
 	if err != nil {
 		return Response{}, fmt.Errorf("unable to marshal data: %w", err)

--- a/clients/openpipeline/openpipeline.go
+++ b/clients/openpipeline/openpipeline.go
@@ -108,32 +108,32 @@ func (c Client) GetAll(ctx context.Context) ([]Response, error) {
 	return resources, nil
 }
 
-func (c Client) Update(ctx context.Context, id string, data []byte) (Response, error) {
+func (c Client) Update(ctx context.Context, id string, payload []byte) (Response, error) {
 	getResp, err := c.Get(ctx, id)
 	if err != nil {
 		return Response{}, err
 	}
 
-	var m map[string]interface{}
-	err = json.Unmarshal(getResp.Data, &m)
+	var remoteJson map[string]any
+	err = json.Unmarshal(getResp.Data, &remoteJson)
 	if err != nil {
 		return Response{}, err
 	}
 
-	var d map[string]interface{}
-	err = json.Unmarshal(data, &d)
+	var localJson map[string]any
+	err = json.Unmarshal(payload, &localJson)
 	if err != nil {
 		return Response{}, err
 	}
 
-	d["version"] = m["version"]
-	d["updateToken"] = m["updateToken"]
-	data, err = json.Marshal(d)
+	localJson["version"] = remoteJson["version"]
+	localJson["updateToken"] = remoteJson["updateToken"]
+	payload, err = json.Marshal(localJson)
 	if err != nil {
-		return Response{}, fmt.Errorf("unable to marshal data: %w", err)
+		return Response{}, fmt.Errorf("unable to marshal payload: %w", err)
 	}
 
-	resp, err := c.client.Update(ctx, id, data, rest.RequestOptions{})
+	resp, err := c.client.Update(ctx, id, payload, rest.RequestOptions{})
 	if err != nil {
 		return Response{}, fmt.Errorf("failed to list openpipeline resources: %w", err)
 	}

--- a/clients/openpipeline/openpipeline_test.go
+++ b/clients/openpipeline/openpipeline_test.go
@@ -16,14 +16,16 @@ package openpipeline_test
 
 import (
 	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/clients/openpipeline"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/testutils"
-	"github.com/stretchr/testify/assert"
-	"io"
-	"net/http"
-	"testing"
 )
 
 func TestOpenPipelineClient_Get(t *testing.T) {
@@ -325,17 +327,18 @@ func TestOpenPipelineClient_GetAll(t *testing.T) {
 func TestOpenPipelineClient_Update(t *testing.T) {
 
 	const getPayload = `{
-	"id": "bizevents",
-	"editable": true,
-	"version": "1716904550612-4770deb9105b4a5293c1edbcc6bf4412"
-}
-`
+		"id": "bizevents",
+		"editable": true,
+		"version": "1716904550612-4770deb9105b4a5293c1edbcc6bf4412",
+		"updateToken": "my-update-token"
+	}
+	`
 
 	const putPayload = `{
-	"id": "bizevents",
-	"editable": true
-}
-`
+		"id": "bizevents",
+		"editable": true
+	}
+	`
 
 	t.Run("PUT - no ID given", func(t *testing.T) {
 		responses := []testutils.ResponseDef{}
@@ -373,6 +376,7 @@ func TestOpenPipelineClient_Update(t *testing.T) {
 					var m map[string]interface{}
 					json.Unmarshal(body, &m)
 					assert.Equal(t, "1716904550612-4770deb9105b4a5293c1edbcc6bf4412", m["version"])
+					assert.Equal(t, "my-update-token", m["updateToken"])
 				},
 			},
 		}


### PR DESCRIPTION

#### What this PR does / Why we need it:
During an update, set the updateToken accordingly. 

To update an OpenPipeline configuration, the `updateToken` must be either empty or set to the latest version. To be consistent with existing code, we set the `updateToken`.
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
No
