### PR TITLE
refactor: Improve segments clients

### DIFF
--- a/api/clients/segements/segments.go
+++ b/api/clients/segements/segments.go
@@ -49,7 +49,7 @@ func (c Client) List(ctx context.Context, ro rest.RequestOptions) (*http.Respons
 
 	r, err := c.client.GET(ctx, path, ro)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get the list of segments: %w", err)
+		return nil, fmt.Errorf("failed to list segments: %w", err)
 	}
 
 	return r, nil
@@ -60,7 +60,7 @@ func (c Client) List(ctx context.Context, ro rest.RequestOptions) (*http.Respons
 func (c Client) Get(ctx context.Context, id string, ro rest.RequestOptions) (*http.Response, error) {
 	path, err := url.JoinPath(endpointPath, id)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create URL: %w", err)
+		return nil, fmt.Errorf("failed to join URL: %w", err)
 	}
 
 	// set default behavior to pick request for all information
@@ -70,7 +70,7 @@ func (c Client) Get(ctx context.Context, id string, ro rest.RequestOptions) (*ht
 
 	r, err := c.client.GET(ctx, path, ro)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get configuration with ID %s: %w", id, err)
+		return nil, fmt.Errorf("failed to get segment with ID %s: %w", id, err)
 	}
 
 	return r, nil
@@ -92,7 +92,7 @@ func (c Client) Update(ctx context.Context, id string, data []byte, ro rest.Requ
 
 	r, err := c.client.PUT(ctx, path, bytes.NewReader(data), ro)
 	if err != nil {
-		return nil, fmt.Errorf("failed to update configuration with ID %s: %w", id, err)
+		return nil, fmt.Errorf("failed to update segment with ID %s: %w", id, err)
 	}
 	return r, nil
 }
@@ -101,14 +101,15 @@ func (c Client) Delete(ctx context.Context, id string, ro rest.RequestOptions) (
 	if id == "" {
 		return nil, fmt.Errorf("id must be non-empty")
 	}
+
 	path, err := url.JoinPath(endpointPath, id)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create URL: %w", err)
+		return nil, fmt.Errorf("failed to join URL: %w", err)
 	}
 
 	r, err := c.client.DELETE(ctx, path, ro)
 	if err != nil {
-		return nil, fmt.Errorf("failed to delete configuration with ID %s: %w", id, err)
+		return nil, fmt.Errorf("failed to delete segment with ID %s: %w", id, err)
 	}
 	return r, nil
 }

--- a/api/clients/segments/segments.go
+++ b/api/clients/segments/segments.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package segements
+package segments
 
 import (
 	"bytes"

--- a/api/clients/segments/segments.go
+++ b/api/clients/segments/segments.go
@@ -58,6 +58,10 @@ func (c Client) List(ctx context.Context, ro rest.RequestOptions) (*http.Respons
 // Get segment with UID.
 // If the field 'add-fields' in [rest.RequestOptions.QueryParams] is not specified, it will be set to "INCLUDES", "VARIABLES", "EXTERNALID", "RESOURCECONTEXT".
 func (c Client) Get(ctx context.Context, id string, ro rest.RequestOptions) (*http.Response, error) {
+	if id == "" {
+		return nil, fmt.Errorf("id must be non-empty")
+	}
+
 	path, err := url.JoinPath(endpointPath, id)
 	if err != nil {
 		return nil, fmt.Errorf("failed to join URL: %w", err)
@@ -85,6 +89,10 @@ func (c Client) Create(ctx context.Context, data []byte, ro rest.RequestOptions)
 }
 
 func (c Client) Update(ctx context.Context, id string, data []byte, ro rest.RequestOptions) (*http.Response, error) {
+	if id == "" {
+		return nil, fmt.Errorf("id must be non-empty")
+	}
+
 	path, err := url.JoinPath(endpointPath, id)
 	if err != nil {
 		return nil, fmt.Errorf("failed to join URL: %w", err)

--- a/api/clients/segments/segments_test.go
+++ b/api/clients/segments/segments_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package segements_test
+package segments_test
 
 import (
 	"context"
@@ -23,7 +23,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/clients/segements"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/clients/segments"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
 )
 
@@ -38,7 +38,7 @@ func TestList(t *testing.T) {
 		u, err := url.Parse(server.URL)
 		require.NoError(t, err)
 
-		c := segements.NewClient(rest.NewClient(u, server.Client()))
+		c := segments.NewClient(rest.NewClient(u, server.Client()))
 
 		resp, err := c.List(context.TODO(), rest.RequestOptions{})
 		require.NoError(t, err)
@@ -57,7 +57,7 @@ func TestList(t *testing.T) {
 		u, err := url.Parse(server.URL)
 		require.NoError(t, err)
 
-		c := segements.NewClient(rest.NewClient(u, server.Client()))
+		c := segments.NewClient(rest.NewClient(u, server.Client()))
 
 		resp, err := c.List(context.TODO(), rest.RequestOptions{})
 		require.NoError(t, err)
@@ -76,7 +76,7 @@ func TestList(t *testing.T) {
 		u, err := url.Parse(server.URL)
 		require.NoError(t, err)
 
-		c := segements.NewClient(rest.NewClient(u, server.Client()))
+		c := segments.NewClient(rest.NewClient(u, server.Client()))
 
 		resp, err := c.List(context.TODO(), rest.RequestOptions{QueryParams: url.Values{"add-fields": []string{"user_defined"}}})
 		require.NoError(t, err)
@@ -96,7 +96,7 @@ func TestGet(t *testing.T) {
 		u, err := url.Parse(server.URL)
 		require.NoError(t, err)
 
-		c := segements.NewClient(rest.NewClient(u, server.Client()))
+		c := segments.NewClient(rest.NewClient(u, server.Client()))
 
 		resp, err := c.Get(context.TODO(), "uid", rest.RequestOptions{})
 		require.NoError(t, err)
@@ -114,7 +114,7 @@ func TestGet(t *testing.T) {
 		u, err := url.Parse(server.URL)
 		require.NoError(t, err)
 
-		c := segements.NewClient(rest.NewClient(u, server.Client()))
+		c := segments.NewClient(rest.NewClient(u, server.Client()))
 
 		resp, err := c.Get(context.TODO(), "id", rest.RequestOptions{})
 		require.NoError(t, err)
@@ -132,7 +132,7 @@ func TestGet(t *testing.T) {
 		u, err := url.Parse(server.URL)
 		require.NoError(t, err)
 
-		c := segements.NewClient(rest.NewClient(u, server.Client()))
+		c := segments.NewClient(rest.NewClient(u, server.Client()))
 
 		resp, err := c.Get(context.TODO(), "id", rest.RequestOptions{QueryParams: url.Values{"add-fields": []string{"user_defined"}}})
 		require.NoError(t, err)
@@ -151,7 +151,7 @@ func TestCreate(t *testing.T) {
 	u, err := url.Parse(server.URL)
 	require.NoError(t, err)
 
-	c := segements.NewClient(rest.NewClient(u, server.Client()))
+	c := segments.NewClient(rest.NewClient(u, server.Client()))
 
 	resp, err := c.Create(context.TODO(), []byte{}, rest.RequestOptions{})
 	require.NoError(t, err)
@@ -169,7 +169,7 @@ func TestUpdate(t *testing.T) {
 	u, err := url.Parse(server.URL)
 	require.NoError(t, err)
 
-	c := segements.NewClient(rest.NewClient(u, server.Client()))
+	c := segments.NewClient(rest.NewClient(u, server.Client()))
 
 	resp, err := c.Update(context.TODO(), "uid", []byte{}, rest.RequestOptions{})
 	require.NoError(t, err)
@@ -187,7 +187,7 @@ func TestDelete(t *testing.T) {
 	u, err := url.Parse(server.URL)
 	require.NoError(t, err)
 
-	c := segements.NewClient(rest.NewClient(u, server.Client()))
+	c := segments.NewClient(rest.NewClient(u, server.Client()))
 
 	resp, err := c.Delete(context.TODO(), "uid", rest.RequestOptions{})
 	require.NoError(t, err)

--- a/api/clients/segments/segments_test.go
+++ b/api/clients/segments/segments_test.go
@@ -21,10 +21,12 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/clients/segments"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/testutils"
 )
 
 func TestList(t *testing.T) {
@@ -104,6 +106,19 @@ func TestGet(t *testing.T) {
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 	})
 
+	t.Run("Returns error for missing id", func(t *testing.T) {
+		responses := []testutils.ResponseDef{}
+		server := testutils.NewHTTPTestServer(t, responses)
+		defer server.Close()
+
+		client := segments.NewClient(rest.NewClient(server.URL(), server.Client()))
+
+		ctx := testutils.ContextWithLogger(t)
+		resp, err := client.Get(ctx, "", rest.RequestOptions{})
+		assert.Zero(t, resp)
+		assert.ErrorContains(t, err, "id")
+	})
+
 	t.Run("add-fields are NOT specified", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			t.Log(r.URL.String())
@@ -160,37 +175,69 @@ func TestCreate(t *testing.T) {
 }
 
 func TestUpdate(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Log(r.URL.String())
-		require.Equal(t, http.MethodPut, r.Method)
-		require.Equal(t, "/platform/storage/filter-segments/v1/filter-segments/uid", r.URL.Path)
-	}))
-	defer server.Close()
-	u, err := url.Parse(server.URL)
-	require.NoError(t, err)
 
-	c := segments.NewClient(rest.NewClient(u, server.Client()))
+	t.Run("check call", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Log(r.URL.String())
+			require.Equal(t, http.MethodPut, r.Method)
+			require.Equal(t, "/platform/storage/filter-segments/v1/filter-segments/uid", r.URL.Path)
+		}))
+		defer server.Close()
+		u, err := url.Parse(server.URL)
+		require.NoError(t, err)
 
-	resp, err := c.Update(context.TODO(), "uid", []byte{}, rest.RequestOptions{})
-	require.NoError(t, err)
+		c := segments.NewClient(rest.NewClient(u, server.Client()))
 
-	require.Equal(t, http.StatusOK, resp.StatusCode)
+		resp, err := c.Update(context.TODO(), "uid", []byte{}, rest.RequestOptions{})
+		require.NoError(t, err)
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("Returns error for missing id", func(t *testing.T) {
+		responses := []testutils.ResponseDef{}
+		server := testutils.NewHTTPTestServer(t, responses)
+		defer server.Close()
+
+		client := segments.NewClient(rest.NewClient(server.URL(), server.Client()))
+
+		ctx := testutils.ContextWithLogger(t)
+		resp, err := client.Update(ctx, "", []byte{}, rest.RequestOptions{})
+		assert.Zero(t, resp)
+		assert.ErrorContains(t, err, "id")
+	})
 }
 
 func TestDelete(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Log(r.URL.String())
-		require.Equal(t, http.MethodDelete, r.Method)
-		require.Equal(t, "/platform/storage/filter-segments/v1/filter-segments/uid", r.URL.Path)
-	}))
-	defer server.Close()
-	u, err := url.Parse(server.URL)
-	require.NoError(t, err)
+	t.Run("check call", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Log(r.URL.String())
+			require.Equal(t, http.MethodDelete, r.Method)
+			require.Equal(t, "/platform/storage/filter-segments/v1/filter-segments/uid", r.URL.Path)
+		}))
+		defer server.Close()
+		u, err := url.Parse(server.URL)
+		require.NoError(t, err)
 
-	c := segments.NewClient(rest.NewClient(u, server.Client()))
+		c := segments.NewClient(rest.NewClient(u, server.Client()))
 
-	resp, err := c.Delete(context.TODO(), "uid", rest.RequestOptions{})
-	require.NoError(t, err)
+		resp, err := c.Delete(context.TODO(), "uid", rest.RequestOptions{})
+		require.NoError(t, err)
 
-	require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("Returns error for missing id", func(t *testing.T) {
+		responses := []testutils.ResponseDef{}
+		server := testutils.NewHTTPTestServer(t, responses)
+		defer server.Close()
+
+		client := segments.NewClient(rest.NewClient(server.URL(), server.Client()))
+
+		ctx := testutils.ContextWithLogger(t)
+		resp, err := client.Delete(ctx, "", rest.RequestOptions{})
+		assert.Zero(t, resp)
+		assert.ErrorContains(t, err, "id")
+	})
+
 }

--- a/clients/segments/segment_test.go
+++ b/clients/segments/segment_test.go
@@ -76,16 +76,6 @@ func TestList(t *testing.T) {
 }
 
 func TestGet(t *testing.T) {
-	t.Run("call without ID returns an error", func(t *testing.T) {
-		ctx := testutils.ContextWithLogger(t)
-		fsClient := segments.NewTestClient(segments.NewMockclient(gomock.NewController(t)))
-		resp, err := fsClient.Get(ctx, "")
-
-		assert.Empty(t, resp)
-		assert.Error(t, err)
-		assert.ErrorContains(t, err, "missing required id")
-	})
-
 	t.Run("ID doesn't exists on server returns error", func(t *testing.T) {
 		apiResponse := `{
   "error": {
@@ -458,16 +448,6 @@ func TestUpsert(t *testing.T) {
 }
 
 func TestDelete(t *testing.T) {
-	t.Run("call without ID returns an error", func(t *testing.T) {
-		ctx := testutils.ContextWithLogger(t)
-		fsClient := segments.NewTestClient(segments.NewMockclient(gomock.NewController(t)))
-		resp, err := fsClient.Delete(ctx, "")
-
-		assert.Empty(t, resp)
-		assert.Error(t, err)
-		assert.ErrorContains(t, err, "missing required id")
-	})
-
 	t.Run("ID doesn't exists on server returns error", func(t *testing.T) {
 		apiResponse := `{
 	 "error": {

--- a/clients/segments/segments.go
+++ b/clients/segments/segments.go
@@ -23,7 +23,7 @@ import (
 	"net/http"
 
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api"
-	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/clients/segements"
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/clients/segments"
 	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
 )
 
@@ -31,7 +31,7 @@ type Response = api.Response
 
 func NewClient(client *rest.Client) *Client {
 	c := &Client{
-		client: segements.NewClient(client),
+		client: segments.NewClient(client),
 	}
 	return c
 }
@@ -50,7 +50,7 @@ type client interface {
 	Delete(ctx context.Context, id string, ro rest.RequestOptions) (*http.Response, error)
 }
 
-var _ client = (*segements.Client)(nil)
+var _ client = (*segments.Client)(nil)
 
 // List gets a complete set of available configs. The Data filed in response is normalized to json list of entries.
 func (c Client) List(ctx context.Context) (Response, error) {

--- a/clients/segments/segments.go
+++ b/clients/segments/segments.go
@@ -17,7 +17,6 @@ package segments
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -77,10 +76,6 @@ func normalizeListResponse(source []byte) ([]byte, error) {
 
 // Get gets a complete configuration of segment with an ID
 func (c Client) Get(ctx context.Context, id string) (Response, error) {
-	if id == "" {
-		return Response{}, errors.New("missing required id")
-	}
-
 	resp, err := c.client.Get(ctx, id, rest.RequestOptions{CustomShouldRetryFunc: rest.RetryIfTooManyRequests})
 	defer closeBody(resp)
 	if err != nil {
@@ -184,10 +179,6 @@ func processResponse(httpResponse *http.Response, transform func([]byte) ([]byte
 
 // Delete removes configuration for segment with given ID from a server.
 func (c Client) Delete(ctx context.Context, id string) (Response, error) {
-	if id == "" {
-		return Response{}, errors.New("missing required id")
-	}
-
 	resp, err := c.client.Delete(ctx, id, rest.RequestOptions{CustomShouldRetryFunc: rest.RetryIfTooManyRequests})
 	closeBody(resp)
 	if err != nil {


### PR DESCRIPTION
This PR suggests a few minor changes to the segments client found while reviewing other code in the area:
-  makes several error messages more consistent
- fixes a typo in segments package name
- moves checks for empty IDs to the segments API client