### PR TITLE
feat: Support `originAppId` in document metadata

### DIFF
--- a/clients/documents/documents_test.go
+++ b/clients/documents/documents_test.go
@@ -55,7 +55,8 @@ Content-Type: application/json
 	"externalId": "extId",
     "type": "dashboard",
     "version": 1,
-    "owner": "12341234-1234-1234-1234-12341234"
+    "owner": "12341234-1234-1234-1234-12341234",
+	"originAppId": "mytest.app"
 }
 --Aas2UU1KdxSpaAyiNZ4-tnuzbwqnKuNK8vMOGy
 Content-Disposition: form-data; name="content"; filename="my-test-db"
@@ -104,6 +105,8 @@ This is the document content
 		assert.Equal(t, "dashboard", resp.Type)
 		assert.Equal(t, 1, resp.Version)
 		assert.Equal(t, "12341234-1234-1234-1234-12341234", resp.Owner)
+		assert.NotNil(t, resp.OriginAppID)
+		assert.Equal(t, "mytest.app", *resp.OriginAppID)
 		assert.Equal(t, "This is the document content", string(resp.Data))
 		assert.NotZero(t, resp.Request)
 		assert.Nil(t, err)

--- a/clients/documents/metadata.go
+++ b/clients/documents/metadata.go
@@ -19,14 +19,15 @@ package documents
 import "encoding/json"
 
 type Metadata struct {
-	ID         string `json:"id"`
-	ExternalID string `json:"externalId"`
-	Actor      string `json:"actor"`
-	Owner      string `json:"owner"`
-	Name       string `json:"name"`
-	Type       string `json:"type"`
-	Version    int    `json:"version"`
-	IsPrivate  bool   `json:"isPrivate"`
+	ID          string  `json:"id"`
+	ExternalID  string  `json:"externalId"`
+	Actor       string  `json:"actor"`
+	Owner       string  `json:"owner"`
+	Name        string  `json:"name"`
+	Type        string  `json:"type"`
+	Version     int     `json:"version"`
+	IsPrivate   bool    `json:"isPrivate"`
+	OriginAppID *string `json:"originAppId,omitempty"`
 }
 
 func UnmarshallMetadata(b []byte) (Metadata, error) {


### PR DESCRIPTION
This PR adds `originAppId` to `documents.Metadata`, as needed for https://github.com/Dynatrace/dynatrace-configuration-as-code/pull/1674