### PR TITLE
chore(segments): split segments `upsert` into `create` and `update`

### DIFF
--- a/api/clients/segments/segments_test.go
+++ b/api/clients/segments/segments_test.go
@@ -176,7 +176,7 @@ func TestCreate(t *testing.T) {
 
 func TestUpdate(t *testing.T) {
 
-	t.Run("check call", func(t *testing.T) {
+	t.Run("add owner and uid", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			t.Log(r.URL.String())
 			require.Equal(t, http.MethodPut, r.Method)
@@ -193,7 +193,6 @@ func TestUpdate(t *testing.T) {
 
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 	})
-
 	t.Run("Returns error for missing id", func(t *testing.T) {
 		responses := []testutils.ResponseDef{}
 		server := testutils.NewHTTPTestServer(t, responses)

--- a/clients/segments/segment_test.go
+++ b/clients/segments/segment_test.go
@@ -269,39 +269,7 @@ func TestGetAll(t *testing.T) {
 	})
 }
 
-func TestUpsert(t *testing.T) {
-
-	t.Run("unexpected error while checking for status on server", func(t *testing.T) {
-		payload := `{
-  "uid": "qW5qn449RsG",
-  "name": "dev_environment",
-  "description": "only includes data of the dev environment",
-  "variables": {
-    "type": "query",
-    "value": "fetch logs | limit 1"
-  },
-  "isPublic": false,
-  "owner": "2f321c04-566e-4779-b576-3c033b8cd9e9",
-  "allowedOperations": [
-    "READ",
-    "WRITE",
-    "DELETE"
-  ],
-  "includes": []
-}`
-		ctx := testutils.ContextWithLogger(t)
-		mockClient := segments.NewMockclient(gomock.NewController(t))
-		mockClient.EXPECT().
-			Get(ctx, "uid", gomock.Any()).
-			Return(nil, errors.New("some unexpected error"))
-
-		fsClient := segments.NewTestClient(mockClient)
-		actual, err := fsClient.Upsert(ctx, "uid", []byte(payload))
-
-		require.Error(t, err)
-		require.Empty(t, actual)
-	})
-
+func TestCreate(t *testing.T) {
 	t.Run("successfully created new entity on server", func(t *testing.T) {
 		payload := `{
   "name": "dev_environment",
@@ -342,12 +310,46 @@ func TestUpsert(t *testing.T) {
 			}, nil)
 
 		fsClient := segments.NewTestClient(mockClient)
-		resp, err := fsClient.Upsert(ctx, "", []byte(payload))
+		resp, err := fsClient.Create(ctx, []byte(payload))
 
 		assert.NotEmpty(t, resp)
 		assert.NoError(t, err)
 		assert.Equal(t, apiResponse, string(resp.Data))
 		assert.Equal(t, http.StatusCreated, resp.StatusCode)
+	})
+}
+
+func TestUpdate(t *testing.T) {
+
+	t.Run("unexpected error while checking for status on server", func(t *testing.T) {
+		payload := `{
+  "uid": "qW5qn449RsG",
+  "name": "dev_environment",
+  "description": "only includes data of the dev environment",
+  "variables": {
+    "type": "query",
+    "value": "fetch logs | limit 1"
+  },
+  "isPublic": false,
+  "owner": "2f321c04-566e-4779-b576-3c033b8cd9e9",
+  "allowedOperations": [
+    "READ",
+    "WRITE",
+    "DELETE"
+  ],
+  "includes": []
+}`
+		ctx := testutils.ContextWithLogger(t)
+		mockClient := segments.NewMockclient(gomock.NewController(t))
+		mockClient.EXPECT().
+			Get(ctx, "uid", gomock.Any()).
+			Return(nil, errors.New("some unexpected error"))
+
+		fsClient := segments.NewTestClient(mockClient)
+		actual, err := fsClient.Update(ctx, "uid", []byte(payload))
+
+		require.Error(t, err)
+		require.Empty(t, actual)
 	})
 
 	t.Run("successfully updated existing entity on server", func(t *testing.T) {
@@ -409,7 +411,7 @@ func TestUpsert(t *testing.T) {
 			})
 
 		fsClient := segments.NewTestClient(mockClient)
-		resp, err := fsClient.Upsert(ctx, "uid", []byte(payload))
+		resp, err := fsClient.Update(ctx, "uid", []byte(payload))
 
 		assert.NotEmpty(t, resp)
 		assert.NoError(t, err)
@@ -456,24 +458,24 @@ func TestUpsert(t *testing.T) {
 		ctx := testutils.ContextWithLogger(t)
 		mockClient := segments.NewMockclient(gomock.NewController(t))
 		mockClient.EXPECT().
-			Get(ctx, "uid", gomock.Any()).
+			Get(ctx, "D82a1jdA23a", gomock.Any()).
 			Return(&http.Response{
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(strings.NewReader(apiExistingResource)),
 			}, nil)
 		mockClient.EXPECT().
-			Update(ctx, "uid", gomock.Any(), gomock.AssignableToTypeOf(rest.RequestOptions{})).
+			Update(ctx, "D82a1jdA23a", gomock.Any(), gomock.AssignableToTypeOf(rest.RequestOptions{})).
 			Return(&http.Response{
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(strings.NewReader(apiResponse)),
 			}, nil).
 			Do(func(_, _, payload any, ro any) {
 				assertVersionParam(t, ro, "2")
-				assertRequestPayload(payload, t, "uid", "2f321c04-566e-4779-b576-3c033b8cd9e9")
+				assertRequestPayload(payload, t, "D82a1jdA23a", "2f321c04-566e-4779-b576-3c033b8cd9e9")
 			})
 
 		fsClient := segments.NewTestClient(mockClient)
-		resp, err := fsClient.Upsert(ctx, "uid", []byte(payload))
+		resp, err := fsClient.Update(ctx, "D82a1jdA23a", []byte(payload))
 
 		assert.NotEmpty(t, resp)
 		assert.NoError(t, err)

--- a/clients/segments/segments.go
+++ b/clients/segments/segments.go
@@ -117,9 +117,7 @@ func (c Client) GetAll(ctx context.Context) ([]Response, error) {
 // In the first step GET is called to get mandatory data by the API(owner, uid and version), this is then added to payload.
 func (c Client) Update(ctx context.Context, id string, data []byte) (Response, error) {
 	existing, err := c.client.Get(ctx, id, rest.RequestOptions{CustomShouldRetryFunc: rest.RetryIfTooManyRequests})
-	if existing != nil {
-		defer existing.Body.Close()
-	}
+	closeBody(existing)
 	if err != nil {
 		return Response{}, fmt.Errorf(errMsgWithId, "update", id, err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines: https://github.com/Dynatrace/dynatrace-configuration-as-code-core/blob/main/CONTRIBUTING.md

Before submitting this PR, please make sure that:
1. Your code builds without any errors or warnings
2. Your code is covered by unit tests
3. Your branch is rebased on top of current main (`git pull --rebase origin main`)
-->

#### What this PR does / Why we need it:
Split segments `upsert` into `create` and `update` to enable usage for Terraform and keep consistency with other implementations of clients.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" or leave this section empty.
If yes, state how the user is impacted by your changes.
-->
