### PR TITLE
fix: Make service user page and page size integer

### DIFF
--- a/gen/account_management/api_service_user_management.go
+++ b/gen/account_management/api_service_user_management.go
@@ -234,18 +234,18 @@ type ApiGetServiceUsersFromAccountRequest struct {
 	ctx         context.Context
 	ApiService  *ServiceUserManagementAPIService
 	accountUuid string
-	page        *float32
-	pageSize    *float32
+	page        *int32
+	pageSize    *int32
 }
 
 // The number of the requested page. Can be increased as long as **hasNextPage** is true in the response.
-func (r ApiGetServiceUsersFromAccountRequest) Page(page float32) ApiGetServiceUsersFromAccountRequest {
+func (r ApiGetServiceUsersFromAccountRequest) Page(page int32) ApiGetServiceUsersFromAccountRequest {
 	r.page = &page
 	return r
 }
 
 // Defines the requested number of entries for the next page.
-func (r ApiGetServiceUsersFromAccountRequest) PageSize(pageSize float32) ApiGetServiceUsersFromAccountRequest {
+func (r ApiGetServiceUsersFromAccountRequest) PageSize(pageSize int32) ApiGetServiceUsersFromAccountRequest {
 	r.pageSize = &pageSize
 	return r
 }

--- a/gen/specs/account_management/spec_formatted_fixed.json
+++ b/gen/specs/account_management/spec_formatted_fixed.json
@@ -2843,7 +2843,7 @@
                         "in": "query",
                         "description": "The number of the requested page. Can be increased as long as **hasNextPage** is true in the response.",
                         "schema": {
-                            "type": "number"
+                            "type": "integer"
                         }
                     },
                     {
@@ -2852,7 +2852,7 @@
                         "in": "query",
                         "description": "Defines the requested number of entries for the next page.",
                         "schema": {
-                            "type": "number"
+                            "type": "integer"
                         }
                     }
                 ],


### PR DESCRIPTION
This PR manually updates the spec and runs the generator to make `page` and `pageSize` an integer `int32` (rather than a number ending up as a `float32`).