### PR TITLE
chore: Update Go to version 1.24

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -33,13 +33,13 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: ⬇️ Check out code into the Go module directory
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+
       - name: 🛠️ Set up Go 1.x
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 #v5.3.0
         with:
           go-version-file: 'go.mod'
-
-      - name: ⬇️ Check out code into the Go module directory
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: 🏗️ Compile
         run: make compile

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -36,7 +36,7 @@ jobs:
       - name: 🛠️ Set up Go 1.x
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 #v5.3.0
         with:
-          go-version: '~1.22'
+          go-version-file: 'go.mod'
 
       - name: ⬇️ Check out code into the Go module directory
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2

--- a/.github/workflows/dependencies-and-licenses.yml
+++ b/.github/workflows/dependencies-and-licenses.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 #v5.3.0
         with:
-          go-version: '~1.22'
+          go-version-file: 'go.mod'
       - name: Install go-licence-detector
         run: |
           go install go.elastic.co/go-licence-detector@v0.6.0

--- a/.github/workflows/pr-static-code-analysis.yml
+++ b/.github/workflows/pr-static-code-analysis.yml
@@ -20,7 +20,7 @@ jobs:
       - name: 🛠️ Set up Go 1.x
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 #v5.3.0
         with:
-          go-version: '~1.22'
+          go-version-file: 'go.mod'
 
       - name: ⬇️ Check out code into the Go module directory
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2

--- a/.github/workflows/pr-static-code-analysis.yml
+++ b/.github/workflows/pr-static-code-analysis.yml
@@ -17,13 +17,13 @@ jobs:
       contents: read
       checks: write
     steps:
+      - name: ⬇️ Check out code into the Go module directory
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+
       - name: 🛠️ Set up Go 1.x
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 #v5.3.0
         with:
           go-version-file: 'go.mod'
-
-      - name: ⬇️ Check out code into the Go module directory
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: ✍️ Check format
         run: make lint

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-go 1.23
+go 1.24.0
 
 module github.com/dynatrace/dynatrace-configuration-as-code-core
 


### PR DESCRIPTION
#### What this PR does / Why we need it:
Updates go (lib and pipeline) to `1.24`
