### PR TITLE
chore: pass right context

### DIFF
--- a/api/clients/segments/segments_test.go
+++ b/api/clients/segments/segments_test.go
@@ -15,7 +15,6 @@
 package segments_test
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -42,7 +41,7 @@ func TestList(t *testing.T) {
 
 		c := segments.NewClient(rest.NewClient(u, server.Client()))
 
-		resp, err := c.List(context.TODO(), rest.RequestOptions{})
+		resp, err := c.List(t.Context(), rest.RequestOptions{})
 		require.NoError(t, err)
 
 		require.Equal(t, http.StatusOK, resp.StatusCode)
@@ -61,7 +60,7 @@ func TestList(t *testing.T) {
 
 		c := segments.NewClient(rest.NewClient(u, server.Client()))
 
-		resp, err := c.List(context.TODO(), rest.RequestOptions{})
+		resp, err := c.List(t.Context(), rest.RequestOptions{})
 		require.NoError(t, err)
 
 		require.Equal(t, http.StatusOK, resp.StatusCode)
@@ -80,7 +79,7 @@ func TestList(t *testing.T) {
 
 		c := segments.NewClient(rest.NewClient(u, server.Client()))
 
-		resp, err := c.List(context.TODO(), rest.RequestOptions{QueryParams: url.Values{"add-fields": []string{"user_defined"}}})
+		resp, err := c.List(t.Context(), rest.RequestOptions{QueryParams: url.Values{"add-fields": []string{"user_defined"}}})
 		require.NoError(t, err)
 
 		require.Equal(t, http.StatusOK, resp.StatusCode)
@@ -100,7 +99,7 @@ func TestGet(t *testing.T) {
 
 		c := segments.NewClient(rest.NewClient(u, server.Client()))
 
-		resp, err := c.Get(context.TODO(), "uid", rest.RequestOptions{})
+		resp, err := c.Get(t.Context(), "uid", rest.RequestOptions{})
 		require.NoError(t, err)
 
 		require.Equal(t, http.StatusOK, resp.StatusCode)
@@ -131,7 +130,7 @@ func TestGet(t *testing.T) {
 
 		c := segments.NewClient(rest.NewClient(u, server.Client()))
 
-		resp, err := c.Get(context.TODO(), "id", rest.RequestOptions{})
+		resp, err := c.Get(t.Context(), "id", rest.RequestOptions{})
 		require.NoError(t, err)
 
 		require.Equal(t, http.StatusOK, resp.StatusCode)
@@ -149,7 +148,7 @@ func TestGet(t *testing.T) {
 
 		c := segments.NewClient(rest.NewClient(u, server.Client()))
 
-		resp, err := c.Get(context.TODO(), "id", rest.RequestOptions{QueryParams: url.Values{"add-fields": []string{"user_defined"}}})
+		resp, err := c.Get(t.Context(), "id", rest.RequestOptions{QueryParams: url.Values{"add-fields": []string{"user_defined"}}})
 		require.NoError(t, err)
 
 		require.Equal(t, http.StatusOK, resp.StatusCode)
@@ -168,7 +167,7 @@ func TestCreate(t *testing.T) {
 
 	c := segments.NewClient(rest.NewClient(u, server.Client()))
 
-	resp, err := c.Create(context.TODO(), []byte{}, rest.RequestOptions{})
+	resp, err := c.Create(t.Context(), []byte{}, rest.RequestOptions{})
 	require.NoError(t, err)
 
 	require.Equal(t, http.StatusOK, resp.StatusCode)
@@ -188,7 +187,7 @@ func TestUpdate(t *testing.T) {
 
 		c := segments.NewClient(rest.NewClient(u, server.Client()))
 
-		resp, err := c.Update(context.TODO(), "uid", []byte{}, rest.RequestOptions{})
+		resp, err := c.Update(t.Context(), "uid", []byte{}, rest.RequestOptions{})
 		require.NoError(t, err)
 
 		require.Equal(t, http.StatusOK, resp.StatusCode)
@@ -220,7 +219,7 @@ func TestDelete(t *testing.T) {
 
 		c := segments.NewClient(rest.NewClient(u, server.Client()))
 
-		resp, err := c.Delete(context.TODO(), "uid", rest.RequestOptions{})
+		resp, err := c.Delete(t.Context(), "uid", rest.RequestOptions{})
 		require.NoError(t, err)
 
 		require.Equal(t, http.StatusOK, resp.StatusCode)

--- a/api/rest/client_test.go
+++ b/api/rest/client_test.go
@@ -15,11 +15,8 @@
 package rest
 
 import (
-	"context"
 	"errors"
 	"fmt"
-	"github.com/dynatrace/dynatrace-configuration-as-code-core/testutils"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -28,6 +25,10 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/testutils"
 )
 
 func TestNewClient(t *testing.T) {
@@ -69,7 +70,7 @@ func TestClient_CRUD(t *testing.T) {
 	client := NewClient(baseURL, nil)
 
 	t.Run("GET", func(t *testing.T) {
-		resp, err := client.GET(context.Background(), "/test", RequestOptions{})
+		resp, err := client.GET(t.Context(), "/test", RequestOptions{})
 
 		assert.NoError(t, err, "Unexpected error")
 		assert.Equal(t, http.StatusOK, resp.StatusCode, "Expected status code 200")
@@ -78,7 +79,7 @@ func TestClient_CRUD(t *testing.T) {
 	})
 
 	t.Run("POST", func(t *testing.T) {
-		resp, err := client.POST(context.Background(), "/test", nil, RequestOptions{})
+		resp, err := client.POST(t.Context(), "/test", nil, RequestOptions{})
 
 		assert.NoError(t, err, "Unexpected error")
 		assert.Equal(t, http.StatusCreated, resp.StatusCode, "Expected status code 201")
@@ -87,7 +88,7 @@ func TestClient_CRUD(t *testing.T) {
 	})
 
 	t.Run("PUT", func(t *testing.T) {
-		resp, err := client.PUT(context.Background(), "/test", nil, RequestOptions{})
+		resp, err := client.PUT(t.Context(), "/test", nil, RequestOptions{})
 
 		assert.NoError(t, err, "Unexpected error")
 		assert.Equal(t, http.StatusNoContent, resp.StatusCode, "Expected status code 204")
@@ -96,7 +97,7 @@ func TestClient_CRUD(t *testing.T) {
 	})
 
 	t.Run("DELETE", func(t *testing.T) {
-		resp, err := client.DELETE(context.Background(), "/test", RequestOptions{})
+		resp, err := client.DELETE(t.Context(), "/test", RequestOptions{})
 
 		assert.NoError(t, err, "Unexpected error")
 		assert.Equal(t, http.StatusNoContent, resp.StatusCode, "Expected status code 204")
@@ -153,7 +154,7 @@ func TestClient_CRUD_HTTPErrors(t *testing.T) {
 			name:   "DELETE",
 			method: http.MethodDelete,
 			requestFn: func() (*http.Response, error) {
-				return client.DELETE(context.Background(), "/test", RequestOptions{})
+				return client.DELETE(t.Context(), "/test", RequestOptions{})
 			},
 		},
 	}
@@ -347,7 +348,7 @@ func TestClient_WithHTTPListener(t *testing.T) {
 				rw.Write([]byte("{}"))
 			},
 			restClientCalls: func(client *Client) error {
-				_, err := client.GET(context.TODO(), "", RequestOptions{})
+				_, err := client.GET(t.Context(), "", RequestOptions{})
 				return err
 			},
 			expectedRecordsRecorded: 2,

--- a/clients/factory.go
+++ b/clients/factory.go
@@ -132,7 +132,7 @@ func (f factory) WithRetryOptions(retryOptions *rest.RetryOptions) factory {
 }
 
 // AccountClient creates and returns a new instance of accounts.Client for interacting with the accounts API.
-func (f factory) AccountClient() (*accounts.Client, error) {
+func (f factory) AccountClient(ctx context.Context) (*accounts.Client, error) {
 	if f.oauthConfig == nil {
 		return nil, ErrOAuthCredentialsMissing
 	}
@@ -141,7 +141,7 @@ func (f factory) AccountClient() (*accounts.Client, error) {
 		return nil, ErrAccountURLMissing
 	}
 
-	restClient, err := f.createRestClient(f.accountURL, auth.NewOAuthBasedClient(context.TODO(), *(f.oauthConfig)))
+	restClient, err := f.createRestClient(f.accountURL, auth.NewOAuthBasedClient(ctx, *(f.oauthConfig)))
 	if err != nil {
 		return nil, err
 	}
@@ -149,8 +149,8 @@ func (f factory) AccountClient() (*accounts.Client, error) {
 }
 
 // AutomationClient creates and returns a new instance of automation.Client for interacting with the automation API.
-func (f factory) AutomationClient() (*automation.Client, error) {
-	restClient, err := f.CreatePlatformClient()
+func (f factory) AutomationClient(ctx context.Context) (*automation.Client, error) {
+	restClient, err := f.CreatePlatformClient(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -158,8 +158,8 @@ func (f factory) AutomationClient() (*automation.Client, error) {
 }
 
 // BucketClient creates and returns a new instance of buckets.Client for interacting with the bucket API.
-func (f factory) BucketClient() (*buckets.Client, error) {
-	restClient, err := f.CreatePlatformClient()
+func (f factory) BucketClient(ctx context.Context) (*buckets.Client, error) {
+	restClient, err := f.CreatePlatformClient(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -167,8 +167,8 @@ func (f factory) BucketClient() (*buckets.Client, error) {
 }
 
 // DocumentClient creates and returns a new instance of documents.Client for interacting with the document API.
-func (f factory) DocumentClient() (*documents.Client, error) {
-	restClient, err := f.CreatePlatformClient()
+func (f factory) DocumentClient(ctx context.Context) (*documents.Client, error) {
+	restClient, err := f.CreatePlatformClient(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -176,8 +176,8 @@ func (f factory) DocumentClient() (*documents.Client, error) {
 }
 
 // SegmentsClient creates and returns a new instance of segments.Client for interacting with the segments API.
-func (f factory) SegmentsClient() (*segments.Client, error) {
-	restClient, err := f.CreatePlatformClient()
+func (f factory) SegmentsClient(ctx context.Context) (*segments.Client, error) {
+	restClient, err := f.CreatePlatformClient(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -185,8 +185,8 @@ func (f factory) SegmentsClient() (*segments.Client, error) {
 }
 
 // SLOClient creates and returns a new instance of slo.Client for interacting with the SLO API.
-func (f factory) SLOClient() (*slo.Client, error) {
-	restClient, err := f.CreatePlatformClient()
+func (f factory) SLOClient(ctx context.Context) (*slo.Client, error) {
+	restClient, err := f.CreatePlatformClient(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -195,8 +195,8 @@ func (f factory) SLOClient() (*slo.Client, error) {
 
 // BucketClientWithRetrySettings creates and returns a new instance of buckets.Client with non-default retry settings.
 // For details about how retry settings are used, see buckets.WithRetrySettings.
-func (f factory) BucketClientWithRetrySettings(maxRetries int, durationBetweenTries time.Duration, maxWaitDuration time.Duration) (*buckets.Client, error) {
-	restClient, err := f.CreatePlatformClient()
+func (f factory) BucketClientWithRetrySettings(ctx context.Context, maxRetries int, durationBetweenTries time.Duration, maxWaitDuration time.Duration) (*buckets.Client, error) {
+	restClient, err := f.CreatePlatformClient(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -204,8 +204,8 @@ func (f factory) BucketClientWithRetrySettings(maxRetries int, durationBetweenTr
 }
 
 // OpenPipelineClient creates and returns a new instance of openpipeline.Client for interacting with the openPipeline API.
-func (f factory) OpenPipelineClient() (*openpipeline.Client, error) {
-	restClient, err := f.CreatePlatformClient()
+func (f factory) OpenPipelineClient(ctx context.Context) (*openpipeline.Client, error) {
+	restClient, err := f.CreatePlatformClient(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -213,7 +213,7 @@ func (f factory) OpenPipelineClient() (*openpipeline.Client, error) {
 }
 
 // CreatePlatformClient creates a REST client configured for accessing platform APIs.
-func (f factory) CreatePlatformClient() (*rest.Client, error) {
+func (f factory) CreatePlatformClient(ctx context.Context) (*rest.Client, error) {
 	if f.oauthConfig == nil {
 		return nil, ErrOAuthCredentialsMissing
 	}
@@ -222,7 +222,7 @@ func (f factory) CreatePlatformClient() (*rest.Client, error) {
 		return nil, ErrPlatformURLMissing
 	}
 
-	return f.createRestClient(f.platformURL, auth.NewOAuthBasedClient(context.TODO(), *f.oauthConfig))
+	return f.createRestClient(f.platformURL, auth.NewOAuthBasedClient(ctx, *f.oauthConfig))
 }
 
 // CreateClassicClient creates a REST client configured for accessing classic APIs.

--- a/clients/factory_test.go
+++ b/clients/factory_test.go
@@ -45,42 +45,42 @@ func TestClientCreation(t *testing.T) {
 		WithUserAgent("MyUserAgent")
 
 	var clientInstance interface{}
-	clientInstance, err := f.BucketClient()
+	clientInstance, err := f.BucketClient(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, clientInstance)
 	assert.IsType(t, &buckets.Client{}, clientInstance)
 
-	clientInstance, err = f.SegmentsClient()
+	clientInstance, err = f.SegmentsClient(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, clientInstance)
 	assert.IsType(t, &segments.Client{}, clientInstance)
 
-	clientInstance, err = f.SLOClient()
+	clientInstance, err = f.SLOClient(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, clientInstance)
 	assert.IsType(t, &slo.Client{}, clientInstance)
 
-	clientInstance, err = f.AutomationClient()
+	clientInstance, err = f.AutomationClient(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, clientInstance)
 	assert.IsType(t, &automation.Client{}, clientInstance)
 
-	clientInstance, err = f.DocumentClient()
+	clientInstance, err = f.DocumentClient(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, clientInstance)
 	assert.IsType(t, &documents.Client{}, clientInstance)
 
-	clientInstance, err = f.OpenPipelineClient()
+	clientInstance, err = f.OpenPipelineClient(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, clientInstance)
 	assert.IsType(t, &openpipeline.Client{}, clientInstance)
 
-	clientInstance, err = f.AccountClient()
+	clientInstance, err = f.AccountClient(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, clientInstance)
 	assert.IsType(t, &accounts.Client{}, clientInstance)
 
-	restClient, err := f.CreatePlatformClient()
+	restClient, err := f.CreatePlatformClient(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, restClient)
 
@@ -102,36 +102,36 @@ func TestClientMissingPlatformURL(t *testing.T) {
 		WithUserAgent("MyUserAgent")
 
 	var clientInstance interface{}
-	clientInstance, err := f.BucketClient()
+	clientInstance, err := f.BucketClient(t.Context())
 	assert.Nil(t, clientInstance)
 	assert.ErrorIs(t, err, ErrPlatformURLMissing)
 
-	clientInstance, err = f.SegmentsClient()
+	clientInstance, err = f.SegmentsClient(t.Context())
 	assert.Nil(t, clientInstance)
 	assert.ErrorIs(t, err, ErrPlatformURLMissing)
 
-	clientInstance, err = f.SLOClient()
+	clientInstance, err = f.SLOClient(t.Context())
 	assert.Nil(t, clientInstance)
 	assert.ErrorIs(t, err, ErrPlatformURLMissing)
 
-	clientInstance, err = f.AutomationClient()
+	clientInstance, err = f.AutomationClient(t.Context())
 	assert.Nil(t, clientInstance)
 	assert.ErrorIs(t, err, ErrPlatformURLMissing)
 
-	clientInstance, err = f.DocumentClient()
+	clientInstance, err = f.DocumentClient(t.Context())
 	assert.Nil(t, clientInstance)
 	assert.ErrorIs(t, err, ErrPlatformURLMissing)
 
-	clientInstance, err = f.OpenPipelineClient()
+	clientInstance, err = f.OpenPipelineClient(t.Context())
 	assert.Nil(t, clientInstance)
 	assert.ErrorIs(t, err, ErrPlatformURLMissing)
 
-	clientInstance, err = f.AccountClient()
+	clientInstance, err = f.AccountClient(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, clientInstance)
 	assert.IsType(t, &accounts.Client{}, clientInstance)
 
-	restClient, err := f.CreatePlatformClient()
+	restClient, err := f.CreatePlatformClient(t.Context())
 	assert.Nil(t, restClient)
 	assert.ErrorIs(t, err, ErrPlatformURLMissing)
 
@@ -149,35 +149,35 @@ func TestClientMissingOAuthCredentials(t *testing.T) {
 		WithUserAgent("MyUserAgent")
 
 	var clientInstance interface{}
-	clientInstance, err := f.BucketClient()
+	clientInstance, err := f.BucketClient(t.Context())
 	assert.Nil(t, clientInstance)
 	assert.ErrorIs(t, err, ErrOAuthCredentialsMissing)
 
-	clientInstance, err = f.SegmentsClient()
+	clientInstance, err = f.SegmentsClient(t.Context())
 	assert.Nil(t, clientInstance)
 	assert.ErrorIs(t, err, ErrOAuthCredentialsMissing)
 
-	clientInstance, err = f.SLOClient()
+	clientInstance, err = f.SLOClient(t.Context())
 	assert.Nil(t, clientInstance)
 	assert.ErrorIs(t, err, ErrOAuthCredentialsMissing)
 
-	clientInstance, err = f.AutomationClient()
+	clientInstance, err = f.AutomationClient(t.Context())
 	assert.Nil(t, clientInstance)
 	assert.ErrorIs(t, err, ErrOAuthCredentialsMissing)
 
-	clientInstance, err = f.DocumentClient()
+	clientInstance, err = f.DocumentClient(t.Context())
 	assert.Nil(t, clientInstance)
 	assert.ErrorIs(t, err, ErrOAuthCredentialsMissing)
 
-	clientInstance, err = f.OpenPipelineClient()
+	clientInstance, err = f.OpenPipelineClient(t.Context())
 	assert.Nil(t, clientInstance)
 	assert.ErrorIs(t, err, ErrOAuthCredentialsMissing)
 
-	clientInstance, err = f.AccountClient()
+	clientInstance, err = f.AccountClient(t.Context())
 	assert.Nil(t, clientInstance)
 	assert.ErrorIs(t, err, ErrOAuthCredentialsMissing)
 
-	restClient, err := f.CreatePlatformClient()
+	restClient, err := f.CreatePlatformClient(t.Context())
 	assert.Nil(t, restClient)
 	assert.ErrorIs(t, err, ErrOAuthCredentialsMissing)
 
@@ -202,36 +202,36 @@ func TestClientPlatformURLParsingError(t *testing.T) {
 
 	var clientInstance interface{}
 
-	clientInstance, err := f.BucketClient()
+	clientInstance, err := f.BucketClient(t.Context())
 	assert.Nil(t, clientInstance)
 	assert.ErrorContains(t, err, failedToParseURL)
 
-	clientInstance, err = f.SegmentsClient()
+	clientInstance, err = f.SegmentsClient(t.Context())
 	assert.Nil(t, clientInstance)
 	assert.ErrorContains(t, err, failedToParseURL)
 
-	clientInstance, err = f.SLOClient()
+	clientInstance, err = f.SLOClient(t.Context())
 	assert.Nil(t, clientInstance)
 	assert.ErrorContains(t, err, failedToParseURL)
 
-	clientInstance, err = f.AutomationClient()
+	clientInstance, err = f.AutomationClient(t.Context())
 	assert.Nil(t, clientInstance)
 	assert.ErrorContains(t, err, failedToParseURL)
 
-	clientInstance, err = f.DocumentClient()
+	clientInstance, err = f.DocumentClient(t.Context())
 	assert.Nil(t, clientInstance)
 	assert.ErrorContains(t, err, failedToParseURL)
 
-	clientInstance, err = f.OpenPipelineClient()
+	clientInstance, err = f.OpenPipelineClient(t.Context())
 	assert.Nil(t, clientInstance)
 	assert.ErrorContains(t, err, failedToParseURL)
 
-	clientInstance, err = f.AccountClient()
+	clientInstance, err = f.AccountClient(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, clientInstance)
 	assert.IsType(t, &accounts.Client{}, clientInstance)
 
-	restClient, err := f.CreatePlatformClient()
+	restClient, err := f.CreatePlatformClient(t.Context())
 	assert.Nil(t, restClient)
 	assert.ErrorContains(t, err, failedToParseURL)
 
@@ -253,41 +253,41 @@ func TestClientMissingAccountURL(t *testing.T) {
 		WithUserAgent("MyUserAgent")
 
 	var clientInstance interface{}
-	clientInstance, err := f.BucketClient()
+	clientInstance, err := f.BucketClient(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, clientInstance)
 	assert.IsType(t, &buckets.Client{}, clientInstance)
 
-	clientInstance, err = f.SegmentsClient()
+	clientInstance, err = f.SegmentsClient(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, clientInstance)
 	assert.IsType(t, &segments.Client{}, clientInstance)
 
-	clientInstance, err = f.SLOClient()
+	clientInstance, err = f.SLOClient(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, clientInstance)
 	assert.IsType(t, &slo.Client{}, clientInstance)
 
-	clientInstance, err = f.AutomationClient()
+	clientInstance, err = f.AutomationClient(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, clientInstance)
 	assert.IsType(t, &automation.Client{}, clientInstance)
 
-	clientInstance, err = f.DocumentClient()
+	clientInstance, err = f.DocumentClient(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, clientInstance)
 	assert.IsType(t, &documents.Client{}, clientInstance)
 
-	clientInstance, err = f.OpenPipelineClient()
+	clientInstance, err = f.OpenPipelineClient(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, clientInstance)
 	assert.IsType(t, &openpipeline.Client{}, clientInstance)
 
-	clientInstance, err = f.AccountClient()
+	clientInstance, err = f.AccountClient(t.Context())
 	assert.Nil(t, clientInstance)
 	assert.ErrorIs(t, err, ErrAccountURLMissing)
 
-	restClient, err := f.CreatePlatformClient()
+	restClient, err := f.CreatePlatformClient(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, restClient)
 
@@ -310,41 +310,41 @@ func TestClientAccountURLParsingError(t *testing.T) {
 		WithUserAgent("MyUserAgent")
 
 	var clientInstance interface{}
-	clientInstance, err := f.BucketClient()
+	clientInstance, err := f.BucketClient(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, clientInstance)
 	assert.IsType(t, &buckets.Client{}, clientInstance)
 
-	clientInstance, err = f.SegmentsClient()
+	clientInstance, err = f.SegmentsClient(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, clientInstance)
 	assert.IsType(t, &segments.Client{}, clientInstance)
 
-	clientInstance, err = f.SLOClient()
+	clientInstance, err = f.SLOClient(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, clientInstance)
 	assert.IsType(t, &slo.Client{}, clientInstance)
 
-	clientInstance, err = f.AutomationClient()
+	clientInstance, err = f.AutomationClient(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, clientInstance)
 	assert.IsType(t, &automation.Client{}, clientInstance)
 
-	clientInstance, err = f.DocumentClient()
+	clientInstance, err = f.DocumentClient(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, clientInstance)
 	assert.IsType(t, &documents.Client{}, clientInstance)
 
-	clientInstance, err = f.OpenPipelineClient()
+	clientInstance, err = f.OpenPipelineClient(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, clientInstance)
 	assert.IsType(t, &openpipeline.Client{}, clientInstance)
 
-	clientInstance, err = f.AccountClient()
+	clientInstance, err = f.AccountClient(t.Context())
 	assert.Nil(t, clientInstance)
 	assert.ErrorContains(t, err, failedToParseURL)
 
-	restClient, err := f.CreatePlatformClient()
+	restClient, err := f.CreatePlatformClient(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, restClient)
 
@@ -366,42 +366,42 @@ func TestClientMissingClassicURL(t *testing.T) {
 		WithUserAgent("MyUserAgent")
 
 	var clientInstance interface{}
-	clientInstance, err := f.BucketClient()
+	clientInstance, err := f.BucketClient(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, clientInstance)
 	assert.IsType(t, &buckets.Client{}, clientInstance)
 
-	clientInstance, err = f.SegmentsClient()
+	clientInstance, err = f.SegmentsClient(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, clientInstance)
 	assert.IsType(t, &segments.Client{}, clientInstance)
 
-	clientInstance, err = f.SLOClient()
+	clientInstance, err = f.SLOClient(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, clientInstance)
 	assert.IsType(t, &slo.Client{}, clientInstance)
 
-	clientInstance, err = f.AutomationClient()
+	clientInstance, err = f.AutomationClient(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, clientInstance)
 	assert.IsType(t, &automation.Client{}, clientInstance)
 
-	clientInstance, err = f.DocumentClient()
+	clientInstance, err = f.DocumentClient(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, clientInstance)
 	assert.IsType(t, &documents.Client{}, clientInstance)
 
-	clientInstance, err = f.OpenPipelineClient()
+	clientInstance, err = f.OpenPipelineClient(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, clientInstance)
 	assert.IsType(t, &openpipeline.Client{}, clientInstance)
 
-	clientInstance, err = f.AccountClient()
+	clientInstance, err = f.AccountClient(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, clientInstance)
 	assert.IsType(t, &accounts.Client{}, clientInstance)
 
-	restClient, err := f.CreatePlatformClient()
+	restClient, err := f.CreatePlatformClient(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, restClient)
 
@@ -423,42 +423,42 @@ func TestClientMissingAccessToken(t *testing.T) {
 		WithUserAgent("MyUserAgent")
 
 	var clientInstance interface{}
-	clientInstance, err := f.BucketClient()
+	clientInstance, err := f.BucketClient(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, clientInstance)
 	assert.IsType(t, &buckets.Client{}, clientInstance)
 
-	clientInstance, err = f.SegmentsClient()
+	clientInstance, err = f.SegmentsClient(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, clientInstance)
 	assert.IsType(t, &segments.Client{}, clientInstance)
 
-	clientInstance, err = f.SLOClient()
+	clientInstance, err = f.SLOClient(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, clientInstance)
 	assert.IsType(t, &slo.Client{}, clientInstance)
 
-	clientInstance, err = f.AutomationClient()
+	clientInstance, err = f.AutomationClient(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, clientInstance)
 	assert.IsType(t, &automation.Client{}, clientInstance)
 
-	clientInstance, err = f.DocumentClient()
+	clientInstance, err = f.DocumentClient(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, clientInstance)
 	assert.IsType(t, &documents.Client{}, clientInstance)
 
-	clientInstance, err = f.OpenPipelineClient()
+	clientInstance, err = f.OpenPipelineClient(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, clientInstance)
 	assert.IsType(t, &openpipeline.Client{}, clientInstance)
 
-	clientInstance, err = f.AccountClient()
+	clientInstance, err = f.AccountClient(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, clientInstance)
 	assert.IsType(t, &accounts.Client{}, clientInstance)
 
-	restClient, err := f.CreatePlatformClient()
+	restClient, err := f.CreatePlatformClient(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, restClient)
 
@@ -481,42 +481,42 @@ func TestClientClassicURLParsingError(t *testing.T) {
 		WithUserAgent("MyUserAgent")
 
 	var clientInstance interface{}
-	clientInstance, err := f.BucketClient()
+	clientInstance, err := f.BucketClient(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, clientInstance)
 	assert.IsType(t, &buckets.Client{}, clientInstance)
 
-	clientInstance, err = f.SegmentsClient()
+	clientInstance, err = f.SegmentsClient(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, clientInstance)
 	assert.IsType(t, &segments.Client{}, clientInstance)
 
-	clientInstance, err = f.SLOClient()
+	clientInstance, err = f.SLOClient(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, clientInstance)
 	assert.IsType(t, &slo.Client{}, clientInstance)
 
-	clientInstance, err = f.AutomationClient()
+	clientInstance, err = f.AutomationClient(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, clientInstance)
 	assert.IsType(t, &automation.Client{}, clientInstance)
 
-	clientInstance, err = f.DocumentClient()
+	clientInstance, err = f.DocumentClient(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, clientInstance)
 	assert.IsType(t, &documents.Client{}, clientInstance)
 
-	clientInstance, err = f.OpenPipelineClient()
+	clientInstance, err = f.OpenPipelineClient(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, clientInstance)
 	assert.IsType(t, &openpipeline.Client{}, clientInstance)
 
-	clientInstance, err = f.AccountClient()
+	clientInstance, err = f.AccountClient(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, clientInstance)
 	assert.IsType(t, &accounts.Client{}, clientInstance)
 
-	restClient, err := f.CreatePlatformClient()
+	restClient, err := f.CreatePlatformClient(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, restClient)
 

--- a/clients/segments/segment_test.go
+++ b/clients/segments/segment_test.go
@@ -15,7 +15,6 @@
 package segments_test
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -63,14 +62,14 @@ func TestList(t *testing.T) {
 
 	mockClient := segments.NewMockclient(gomock.NewController(t))
 	mockClient.EXPECT().
-		List(gomock.AssignableToTypeOf(context.Background()), gomock.AssignableToTypeOf(rest.RequestOptions{})).
+		List(gomock.AssignableToTypeOf(t.Context()), gomock.AssignableToTypeOf(rest.RequestOptions{})).
 		Return(&http.Response{
 			StatusCode: http.StatusOK,
 			Body:       io.NopCloser(strings.NewReader(apiResponse)),
 		}, nil)
 
 	fsClient := segments.NewTestClient(mockClient)
-	actual, err := fsClient.List(context.Background())
+	actual, err := fsClient.List(t.Context())
 
 	require.NoError(t, err)
 	require.JSONEq(t, expected, string(actual.Data))

--- a/clients/slo/slo_test.go
+++ b/clients/slo/slo_test.go
@@ -15,7 +15,6 @@
 package slo_test
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -102,7 +101,7 @@ func TestList(t *testing.T) {
 		url, _ := url.Parse(server.URL)
 		client := slo.NewClient(rest.NewClient(url, server.Client()))
 
-		resp, err := client.List(context.TODO())
+		resp, err := client.List(t.Context())
 
 		assert.NotEmpty(t, resp)
 		assert.NoError(t, err)
@@ -152,7 +151,7 @@ func TestList(t *testing.T) {
 		url, _ := url.Parse(server.URL)
 		client := slo.NewClient(rest.NewClient(url, server.Client()))
 
-		resp, err := client.List(context.TODO())
+		resp, err := client.List(t.Context())
 
 		assert.Error(t, err)
 		assert.ErrorAs(t, err, new(api.APIError))
@@ -164,7 +163,7 @@ func TestGet(t *testing.T) {
 	t.Run("when called without id parameter, returns an error", func(t *testing.T) {
 		client := slo.NewClient(&rest.Client{})
 
-		actual, err := client.Get(context.TODO(), "")
+		actual, err := client.Get(t.Context(), "")
 
 		assert.Error(t, err)
 		assert.Empty(t, actual)
@@ -204,7 +203,7 @@ func TestGet(t *testing.T) {
 		url, _ := url.Parse(server.URL)
 		client := slo.NewClient(rest.NewClient(url, server.Client()))
 
-		resp, err := client.Get(context.TODO(), "uid")
+		resp, err := client.Get(t.Context(), "uid")
 
 		assert.NoError(t, err)
 		assert.NotEmpty(t, resp)
@@ -229,7 +228,7 @@ func TestGet(t *testing.T) {
 		url, _ := url.Parse(server.URL)
 		client := slo.NewClient(rest.NewClient(url, server.Client()))
 
-		resp, err := client.Get(context.TODO(), "uid")
+		resp, err := client.Get(t.Context(), "uid")
 
 		assert.Empty(t, resp)
 		assert.ErrorAs(t, err, &api.APIError{})
@@ -272,7 +271,7 @@ func TestCreate(t *testing.T) {
 	url, _ := url.Parse(server.URL)
 	client := slo.NewClient(rest.NewClient(url, server.Client()))
 
-	actual, err := client.Create(context.TODO(), json.RawMessage(given))
+	actual, err := client.Create(t.Context(), json.RawMessage(given))
 
 	assert.NoError(t, err)
 	assert.NotEmpty(t, actual)
@@ -283,7 +282,7 @@ func TestUpdate(t *testing.T) {
 	t.Run("when called without id parameter, returns an error", func(t *testing.T) {
 		client := slo.NewClient(&rest.Client{})
 
-		actual, err := client.Update(context.TODO(), "", nil)
+		actual, err := client.Update(t.Context(), "", nil)
 
 		assert.Error(t, err)
 		assert.Empty(t, actual)
@@ -345,7 +344,7 @@ func TestUpdate(t *testing.T) {
 		url, _ := url.Parse(server.URL)
 		client := slo.NewClient(rest.NewClient(url, server.Client()))
 
-		resp, err := client.Update(context.TODO(), "slo-id-1", json.RawMessage(payload))
+		resp, err := client.Update(t.Context(), "slo-id-1", json.RawMessage(payload))
 
 		assert.NotEmpty(t, resp)
 		assert.NoError(t, err)
@@ -368,7 +367,7 @@ func TestUpdate(t *testing.T) {
 		url, _ := url.Parse(server.URL)
 		client := slo.NewClient(rest.NewClient(url, server.Client()))
 
-		resp, err := client.Update(context.TODO(), "uid", nil)
+		resp, err := client.Update(t.Context(), "uid", nil)
 
 		assert.Empty(t, resp)
 		assert.ErrorAs(t, err, &api.APIError{})
@@ -384,7 +383,7 @@ func TestDelete(t *testing.T) {
 	t.Run("when called without id parameter, returns an error", func(t *testing.T) {
 		client := slo.NewClient(&rest.Client{})
 
-		actual, err := client.Delete(context.TODO(), "")
+		actual, err := client.Delete(t.Context(), "")
 
 		assert.Error(t, err)
 		assert.Empty(t, actual)
@@ -429,7 +428,7 @@ func TestDelete(t *testing.T) {
 		url, _ := url.Parse(server.URL)
 		client := slo.NewClient(rest.NewClient(url, server.Client()))
 
-		actual, err := client.Delete(context.TODO(), "slo-id-1")
+		actual, err := client.Delete(t.Context(), "slo-id-1")
 
 		assert.NoError(t, err)
 		assert.Equal(t, actual.StatusCode, http.StatusNoContent)
@@ -452,7 +451,7 @@ func TestDelete(t *testing.T) {
 		url, _ := url.Parse(server.URL)
 		client := slo.NewClient(rest.NewClient(url, server.Client()))
 
-		actual, err := client.Delete(context.TODO(), "uid")
+		actual, err := client.Delete(t.Context(), "uid")
 
 		assert.Empty(t, actual)
 		assert.ErrorAs(t, err, &api.APIError{})

--- a/testutils/testcontext.go
+++ b/testutils/testcontext.go
@@ -16,15 +16,16 @@ package testutils
 
 import (
 	"context"
+	"testing"
+
 	"github.com/go-logr/logr"
 	"github.com/go-logr/logr/testr"
-	"testing"
 )
 
 func ContextWithLogger(t *testing.T) context.Context {
-	return logr.NewContext(context.Background(), testr.New(t))
+	return logr.NewContext(t.Context(), testr.New(t))
 }
 
 func ContextWithVerboseLogger(t *testing.T) context.Context {
-	return logr.NewContext(context.Background(), testr.NewWithOptions(t, testr.Options{Verbosity: 1}))
+	return logr.NewContext(t.Context(), testr.NewWithOptions(t, testr.Options{Verbosity: 1}))
 }


### PR DESCRIPTION
#### What this PR does / Why we need it:
Forwards the correct context to all places
