### PR TITLE
chore: ignore 403 on retry

### DIFF
--- a/api/rest/client.go
+++ b/api/rest/client.go
@@ -19,12 +19,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/go-logr/logr"
-	"github.com/google/uuid"
 	"io"
 	"net/http"
 	"net/url"
 	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/google/uuid"
 )
 
 // RequestOptions are additional options that should be applied
@@ -233,7 +234,7 @@ func (c *Client) sendWithRetries(ctx context.Context, req *http.Request, retryCo
 		c.rateLimiter.Update(ctx, response.StatusCode, response.Header)
 	}
 
-	if c.retryOptions != nil && retryCount < c.retryOptions.MaxRetries {
+	if ShouldRetry(response.StatusCode) && c.retryOptions != nil && retryCount < c.retryOptions.MaxRetries {
 
 		shouldRetryFunc := c.retryOptions.ShouldRetryFunc
 		if options.CustomShouldRetryFunc != nil {

--- a/api/rest/retry.go
+++ b/api/rest/retry.go
@@ -16,11 +16,8 @@ package rest
 
 import (
 	"net/http"
-	"slices"
 	"time"
 )
-
-var ignoredStatusOnRetry = []int{http.StatusForbidden}
 
 type RetryFunc func(resp *http.Response) bool
 
@@ -53,5 +50,14 @@ func isStatusSuccess(statusCode int) bool {
 
 // ShouldRetry returns true if a retry should happen (e.g., not on 403 or 200, but on 429, etc.) which is valid for all kind of APIs
 func ShouldRetry(statusCode int) bool {
-	return !isStatusSuccess(statusCode) && !slices.Contains(ignoredStatusOnRetry, statusCode)
+	if isStatusSuccess(statusCode) {
+		return false
+	}
+
+	switch statusCode {
+	case http.StatusForbidden:
+		return false
+	default:
+		return true
+	}
 }

--- a/api/rest/retry.go
+++ b/api/rest/retry.go
@@ -16,8 +16,11 @@ package rest
 
 import (
 	"net/http"
+	"slices"
 	"time"
 )
+
+var ignoredStatusOnRetry = []int{http.StatusForbidden}
 
 type RetryFunc func(resp *http.Response) bool
 
@@ -30,7 +33,7 @@ type RetryOptions struct {
 
 // RetryIfNotSuccess is a basic retry function which will retry on any non 2xx status code.
 func RetryIfNotSuccess(resp *http.Response) bool {
-	return !(resp.StatusCode >= 200 && resp.StatusCode <= 299)
+	return !(isStatusSuccess(resp.StatusCode))
 }
 
 // RetryIfTooManyRequests return true for responses with status code Too Many Requests (429).
@@ -41,4 +44,14 @@ func RetryIfTooManyRequests(resp *http.Response) bool {
 // RetryOnFailureExcept404 returns true for all failed responses except those with status not found.
 func RetryOnFailureExcept404(resp *http.Response) bool {
 	return RetryIfNotSuccess(resp) && (resp.StatusCode != http.StatusNotFound)
+}
+
+// isStatusSuccess returns true if it is a 2xx status code
+func isStatusSuccess(statusCode int) bool {
+	return statusCode >= 200 && statusCode <= 299
+}
+
+// ShouldRetry returns true if a retry should happen (e.g., not on 403 or 200, but on 429, etc.) which is valid for all kind of APIs
+func ShouldRetry(statusCode int) bool {
+	return !isStatusSuccess(statusCode) && !slices.Contains(ignoredStatusOnRetry, statusCode)
 }

--- a/api/rest/retry_test.go
+++ b/api/rest/retry_test.go
@@ -1,0 +1,56 @@
+// @license
+// Copyright 2023 Dynatrace LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rest_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dynatrace/dynatrace-configuration-as-code-core/api/rest"
+)
+
+func TestShouldRetry(t *testing.T) {
+	testcases := []struct {
+		statusCode int
+		want       bool
+	}{
+		{
+			statusCode: http.StatusOK,
+			want:       false,
+		},
+		{
+			statusCode: http.StatusForbidden,
+			want:       false,
+		},
+		{
+			statusCode: http.StatusNotFound,
+			want:       true,
+		},
+		{
+			statusCode: http.StatusBadRequest,
+			want:       true,
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(fmt.Sprintf("Should be %v if status is %d", tt.want, tt.statusCode), func(t *testing.T) {
+			got := rest.ShouldRetry(tt.statusCode)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/api/rest/retry_test.go
+++ b/api/rest/retry_test.go
@@ -15,7 +15,6 @@
 package rest_test
 
 import (
-	"fmt"
 	"net/http"
 	"testing"
 
@@ -25,32 +24,18 @@ import (
 )
 
 func TestShouldRetry(t *testing.T) {
-	testcases := []struct {
-		statusCode int
-		want       bool
-	}{
-		{
-			statusCode: http.StatusOK,
-			want:       false,
-		},
-		{
-			statusCode: http.StatusForbidden,
-			want:       false,
-		},
-		{
-			statusCode: http.StatusNotFound,
-			want:       true,
-		},
-		{
-			statusCode: http.StatusBadRequest,
-			want:       true,
-		},
-	}
+	t.Run("Should be false if status is 200", func(t *testing.T) {
+		got := rest.ShouldRetry(http.StatusOK)
+		assert.False(t, got)
+	})
 
-	for _, tt := range testcases {
-		t.Run(fmt.Sprintf("Should be %v if status is %d", tt.want, tt.statusCode), func(t *testing.T) {
-			got := rest.ShouldRetry(tt.statusCode)
-			assert.Equal(t, tt.want, got)
-		})
-	}
+	t.Run("Should be false if status is 403", func(t *testing.T) {
+		got := rest.ShouldRetry(http.StatusForbidden)
+		assert.False(t, got)
+	})
+
+	t.Run("Should be true if status is not 403 or 2xx", func(t *testing.T) {
+		got := rest.ShouldRetry(http.StatusNotFound)
+		assert.True(t, got)
+	})
 }


### PR DESCRIPTION
#### What this PR does / Why we need it:
Ignore certain status codes that should not be retried (e.g., 403), because they will always fail

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
