### PR TITLE
refactor: Remove unused `maxRetries` from buckets client

### DIFF
--- a/clients/buckets/bucket.go
+++ b/clients/buckets/bucket.go
@@ -55,7 +55,6 @@ type listResponse struct {
 }
 
 type retrySettings struct {
-	maxRetries           int
 	durationBetweenTries time.Duration
 	maxWaitDuration      time.Duration
 }
@@ -68,18 +67,16 @@ type Client struct {
 // Option represents a functional Option for the Client.
 type Option func(*Client)
 
-// WithRetrySettings sets the maximum number of retries as well as duration between retries.
+// WithRetrySettings sets the maximum retry time as well as duration between retries.
 // These settings are honored wherever retries are used in the Client - most notably in Client.Update and Client.Upsert,
 // as well as Client.Create when waiting for a bucket to become available after creation.
 //
 // Parameters:
-//   - maxRetries: maximum amount actions may be retries. (Some actions may ignore this and only honor maxWaitDuration)
 //   - durationBetweenTries: time.Duration to wait between tries.
 //   - maxWaitDuration: maximum time.Duration to wait before retrying is canceled. If you supply a context.Context with a timeout, the shorter of the two will be honored.
-func WithRetrySettings(maxRetries int, durationBetweenTries time.Duration, maxWaitDuration time.Duration) Option {
+func WithRetrySettings(durationBetweenTries time.Duration, maxWaitDuration time.Duration) Option {
 	return func(c *Client) {
 		c.retrySettings = retrySettings{
-			maxRetries:           maxRetries,
 			durationBetweenTries: durationBetweenTries,
 			maxWaitDuration:      maxWaitDuration,
 		}
@@ -100,7 +97,6 @@ func NewClient(client *rest.Client, option ...Option) *Client {
 	c := &Client{
 		apiClient: bucketAPI.NewClient(client),
 		retrySettings: retrySettings{
-			maxRetries:           15,
 			durationBetweenTries: time.Second,
 			maxWaitDuration:      2 * time.Minute,
 		},

--- a/clients/buckets/bucket_test.go
+++ b/clients/buckets/bucket_test.go
@@ -71,7 +71,8 @@ const (
 }`
 )
 
-const bucketDurationBetweenTries = 0 * time.Second
+// retries without delay for tests
+const noDelayBetweenTries = 0 * time.Second
 const bucketMaxWaitDuration = 30 * time.Second
 
 func TestGet(t *testing.T) {
@@ -92,7 +93,7 @@ func TestGet(t *testing.T) {
 		defer server.Close()
 
 		client := buckets.NewClient(rest.NewClient(server.URL(), server.Client()),
-			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration)) // retries without delay for tests
+			buckets.WithRetrySettings(noDelayBetweenTries, bucketMaxWaitDuration))
 
 		ctx := testutils.ContextWithLogger(t)
 
@@ -117,7 +118,7 @@ func TestGet(t *testing.T) {
 		defer server.Close()
 
 		client := buckets.NewClient(rest.NewClient(server.URL(), server.Client()),
-			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration)) // retries without delay for tests
+			buckets.WithRetrySettings(noDelayBetweenTries, bucketMaxWaitDuration))
 
 		ctx := testutils.ContextWithLogger(t)
 
@@ -172,7 +173,7 @@ func TestList(t *testing.T) {
 		defer server.Close()
 
 		client := buckets.NewClient(rest.NewClient(server.URL(), server.Client()),
-			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration)) // retries without delay for tests
+			buckets.WithRetrySettings(noDelayBetweenTries, bucketMaxWaitDuration))
 
 		ctx := testutils.ContextWithLogger(t)
 
@@ -198,7 +199,7 @@ func TestList(t *testing.T) {
 		defer server.Close()
 
 		client := buckets.NewClient(rest.NewClient(server.URL(), server.Client()),
-			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration)) // retries without delay for tests
+			buckets.WithRetrySettings(noDelayBetweenTries, bucketMaxWaitDuration))
 
 		ctx := testutils.ContextWithLogger(t)
 
@@ -224,7 +225,7 @@ func TestList(t *testing.T) {
 		defer server.Close()
 
 		client := buckets.NewClient(rest.NewClient(server.URL(), server.Client()),
-			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration)) // retries without delay for tests
+			buckets.WithRetrySettings(noDelayBetweenTries, bucketMaxWaitDuration))
 
 		ctx := testutils.ContextWithLogger(t)
 
@@ -290,7 +291,7 @@ func TestUpsert(t *testing.T) {
 		defer server.Close()
 
 		client := buckets.NewClient(rest.NewClient(server.URL(), server.Client()),
-			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration)) // retries without delay for tests
+			buckets.WithRetrySettings(noDelayBetweenTries, bucketMaxWaitDuration))
 		data := []byte("{}")
 
 		ctx := testutils.ContextWithLogger(t)
@@ -331,7 +332,7 @@ func TestUpsert(t *testing.T) {
 		url, _ := url.Parse(server.URL) //nolint:errcheck
 
 		client := buckets.NewClient(rest.NewClient(url, server.Client()),
-			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration)) // retries without delay for tests
+			buckets.WithRetrySettings(noDelayBetweenTries, bucketMaxWaitDuration))
 
 		ctx := testutils.ContextWithLogger(t)
 
@@ -375,7 +376,7 @@ func TestUpsert(t *testing.T) {
 		defer server.Close()
 
 		client := buckets.NewClient(rest.NewClient(server.URL(), server.Client()),
-			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration)) // retries without delay for tests
+			buckets.WithRetrySettings(noDelayBetweenTries, bucketMaxWaitDuration))
 		data := []byte("{}")
 
 		ctx := testutils.ContextWithLogger(t)
@@ -455,7 +456,7 @@ func TestUpsert(t *testing.T) {
 		defer server.Close()
 
 		client := buckets.NewClient(rest.NewClient(server.URL(), server.Client()),
-			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration)) // retries without delay for tests
+			buckets.WithRetrySettings(noDelayBetweenTries, bucketMaxWaitDuration))
 		data := []byte("{}")
 
 		ctx := testutils.ContextWithLogger(t)
@@ -511,7 +512,7 @@ func TestUpsert(t *testing.T) {
 		defer server.Close()
 
 		client := buckets.NewClient(rest.NewClient(server.URL(), server.Client()),
-			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration)) // retries without delay for tests
+			buckets.WithRetrySettings(noDelayBetweenTries, bucketMaxWaitDuration))
 		data := []byte("{}")
 
 		ctx := testutils.ContextWithLogger(t)
@@ -570,7 +571,7 @@ func TestUpsert(t *testing.T) {
 
 		client := buckets.NewClient(
 			rest.NewClient(server.URL(), server.Client()),
-			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration))
+			buckets.WithRetrySettings(noDelayBetweenTries, bucketMaxWaitDuration))
 		data := []byte("{}")
 
 		ctx := testutils.ContextWithLogger(t)
@@ -622,7 +623,7 @@ func TestUpsert(t *testing.T) {
 
 		client := buckets.NewClient(
 			rest.NewClient(server.URL(), server.Client()),
-			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration))
+			buckets.WithRetrySettings(noDelayBetweenTries, bucketMaxWaitDuration))
 		data := []byte("{}")
 
 		ctx := testutils.ContextWithLogger(t)
@@ -701,7 +702,7 @@ func TestUpsert(t *testing.T) {
 		defer server.Close()
 
 		client := buckets.NewClient(rest.NewClient(server.URL(), server.Client()),
-			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration)) // retries without delay for tests
+			buckets.WithRetrySettings(noDelayBetweenTries, bucketMaxWaitDuration))
 		data := []byte(activeBucketResponse)
 
 		ctx := testutils.ContextWithLogger(t)
@@ -796,7 +797,7 @@ func TestUpsert(t *testing.T) {
 		defer server.Close()
 
 		client := buckets.NewClient(rest.NewClient(server.URL(), server.Client()),
-			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration)) // retries without delay for tests
+			buckets.WithRetrySettings(noDelayBetweenTries, bucketMaxWaitDuration))
 		data := []byte("{}")
 
 		ctx := testutils.ContextWithLogger(t)
@@ -846,7 +847,7 @@ func TestDelete(t *testing.T) {
 		defer server.Close()
 
 		client := buckets.NewClient(rest.NewClient(server.URL(), server.Client()),
-			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration)) // retries without delay for tests
+			buckets.WithRetrySettings(noDelayBetweenTries, bucketMaxWaitDuration))
 
 		ctx := testutils.ContextWithLogger(t)
 
@@ -872,7 +873,7 @@ func TestDelete(t *testing.T) {
 		defer server.Close()
 
 		client := buckets.NewClient(rest.NewClient(server.URL(), server.Client()),
-			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration)) // retries without delay for tests
+			buckets.WithRetrySettings(noDelayBetweenTries, bucketMaxWaitDuration))
 
 		ctx := testutils.ContextWithLogger(t)
 
@@ -943,7 +944,7 @@ func TestCreate(t *testing.T) {
 		defer server.Close()
 
 		client := buckets.NewClient(rest.NewClient(server.URL(), server.Client()),
-			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration)) // retries without delay for tests
+			buckets.WithRetrySettings(noDelayBetweenTries, bucketMaxWaitDuration))
 
 		ctx := testutils.ContextWithLogger(t)
 
@@ -979,7 +980,7 @@ func TestCreate(t *testing.T) {
 		url, _ := url.Parse(server.URL) //nolint:errcheck
 
 		client := buckets.NewClient(rest.NewClient(url, server.Client()),
-			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration)) // retries without delay for tests
+			buckets.WithRetrySettings(noDelayBetweenTries, bucketMaxWaitDuration))
 
 		ctx := testutils.ContextWithLogger(t)
 
@@ -1017,7 +1018,7 @@ func TestCreate(t *testing.T) {
 		defer server.Close()
 
 		client := buckets.NewClient(rest.NewClient(server.URL(), server.Client()),
-			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration)) // retries without delay for tests
+			buckets.WithRetrySettings(noDelayBetweenTries, bucketMaxWaitDuration))
 
 		ctx := testutils.ContextWithLogger(t)
 
@@ -1062,7 +1063,7 @@ func TestUpdate(t *testing.T) {
 		defer server.Close()
 
 		client := buckets.NewClient(rest.NewClient(server.URL(), &http.Client{}),
-			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration)) // retries without delay for tests
+			buckets.WithRetrySettings(noDelayBetweenTries, bucketMaxWaitDuration))
 		data := []byte("{}")
 
 		ctx := testutils.ContextWithLogger(t)
@@ -1130,7 +1131,7 @@ func TestUpdate(t *testing.T) {
 		defer server.Close()
 
 		client := buckets.NewClient(rest.NewClient(server.URL(), &http.Client{}),
-			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration)) // retries without delay for tests
+			buckets.WithRetrySettings(noDelayBetweenTries, bucketMaxWaitDuration))
 		data := []byte("{}")
 
 		ctx := testutils.ContextWithLogger(t)
@@ -1164,7 +1165,7 @@ func TestUpdate(t *testing.T) {
 		defer server.Close()
 
 		client := buckets.NewClient(rest.NewClient(server.URL(), server.Client()),
-			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration)) // retries without delay for tests
+			buckets.WithRetrySettings(noDelayBetweenTries, bucketMaxWaitDuration))
 		data := []byte(`{
 	 "bucketName": "bucket name",
 	 "table": "metrics",
@@ -1223,7 +1224,7 @@ func TestUpdate(t *testing.T) {
 
 		client := buckets.NewClient(
 			rest.NewClient(server.URL(), server.Client()),
-			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration))
+			buckets.WithRetrySettings(noDelayBetweenTries, bucketMaxWaitDuration))
 		data := []byte("{}")
 
 		ctx := testutils.ContextWithLogger(t)
@@ -1251,7 +1252,7 @@ func TestUpdate(t *testing.T) {
 		defer server.Close()
 
 		client := buckets.NewClient(rest.NewClient(server.URL(), &http.Client{}),
-			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration)) // retries without delay for tests
+			buckets.WithRetrySettings(noDelayBetweenTries, bucketMaxWaitDuration))
 		data := []byte("{}")
 
 		ctx := testutils.ContextWithLogger(t)
@@ -1289,7 +1290,7 @@ func TestUpdate(t *testing.T) {
 		defer server.Close()
 
 		client := buckets.NewClient(rest.NewClient(server.URL(), &http.Client{}),
-			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration)) // retries without delay for tests
+			buckets.WithRetrySettings(noDelayBetweenTries, bucketMaxWaitDuration))
 		data := []byte("{}")
 
 		ctx := testutils.ContextWithLogger(t)
@@ -1333,7 +1334,7 @@ func TestUpdate(t *testing.T) {
 
 		u, _ := url.Parse(server.URL)
 		client := buckets.NewClient(rest.NewClient(u, &http.Client{}),
-			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration)) // retries without delay for tests
+			buckets.WithRetrySettings(noDelayBetweenTries, bucketMaxWaitDuration))
 		data := []byte("{}")
 
 		ctx := testutils.ContextWithLogger(t)
@@ -1374,7 +1375,7 @@ func TestUpdate(t *testing.T) {
 
 		u, _ := url.Parse(server.URL)
 		client := buckets.NewClient(rest.NewClient(u, &http.Client{}),
-			buckets.WithRetrySettings(0, 0)) // maxWaitDuration should time out immediately
+			buckets.WithRetrySettings(noDelayBetweenTries, 0)) // maxWaitDuration should time out immediately
 		data := []byte("{}")
 
 		ctx := testutils.ContextWithLogger(t)
@@ -1426,7 +1427,7 @@ func TestDecodingBucketResponses(t *testing.T) {
 		defer server.Close()
 
 		client := buckets.NewClient(rest.NewClient(server.URL(), server.Client()),
-			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration)) // retries without delay for tests
+			buckets.WithRetrySettings(noDelayBetweenTries, bucketMaxWaitDuration))
 
 		ctx := testutils.ContextWithLogger(t)
 
@@ -1463,7 +1464,7 @@ func TestDecodingBucketResponses(t *testing.T) {
 		defer server.Close()
 
 		client := buckets.NewClient(rest.NewClient(server.URL(), server.Client()),
-			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration)) // retries without delay for tests
+			buckets.WithRetrySettings(noDelayBetweenTries, bucketMaxWaitDuration))
 
 		ctx := testutils.ContextWithLogger(t)
 

--- a/clients/buckets/bucket_test.go
+++ b/clients/buckets/bucket_test.go
@@ -71,6 +71,9 @@ const (
 }`
 )
 
+const bucketDurationBetweenTries = 0 * time.Second
+const bucketMaxWaitDuration = 30 * time.Second
+
 func TestGet(t *testing.T) {
 	t.Run("successfully fetch a bucket", func(t *testing.T) {
 
@@ -89,7 +92,7 @@ func TestGet(t *testing.T) {
 		defer server.Close()
 
 		client := buckets.NewClient(rest.NewClient(server.URL(), server.Client()),
-			buckets.WithRetrySettings(5, 0, 2*time.Minute)) // retries without delay for tests
+			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration)) // retries without delay for tests
 
 		ctx := testutils.ContextWithLogger(t)
 
@@ -114,7 +117,7 @@ func TestGet(t *testing.T) {
 		defer server.Close()
 
 		client := buckets.NewClient(rest.NewClient(server.URL(), server.Client()),
-			buckets.WithRetrySettings(5, 0, 2*time.Minute)) // retries without delay for tests
+			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration)) // retries without delay for tests
 
 		ctx := testutils.ContextWithLogger(t)
 
@@ -169,7 +172,7 @@ func TestList(t *testing.T) {
 		defer server.Close()
 
 		client := buckets.NewClient(rest.NewClient(server.URL(), server.Client()),
-			buckets.WithRetrySettings(5, 0, 2*time.Minute)) // retries without delay for tests
+			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration)) // retries without delay for tests
 
 		ctx := testutils.ContextWithLogger(t)
 
@@ -195,7 +198,7 @@ func TestList(t *testing.T) {
 		defer server.Close()
 
 		client := buckets.NewClient(rest.NewClient(server.URL(), server.Client()),
-			buckets.WithRetrySettings(5, 0, 2*time.Minute)) // retries without delay for tests
+			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration)) // retries without delay for tests
 
 		ctx := testutils.ContextWithLogger(t)
 
@@ -221,7 +224,7 @@ func TestList(t *testing.T) {
 		defer server.Close()
 
 		client := buckets.NewClient(rest.NewClient(server.URL(), server.Client()),
-			buckets.WithRetrySettings(5, 0, 2*time.Minute)) // retries without delay for tests
+			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration)) // retries without delay for tests
 
 		ctx := testutils.ContextWithLogger(t)
 
@@ -287,7 +290,7 @@ func TestUpsert(t *testing.T) {
 		defer server.Close()
 
 		client := buckets.NewClient(rest.NewClient(server.URL(), server.Client()),
-			buckets.WithRetrySettings(5, 0, 2*time.Minute)) // retries without delay for tests
+			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration)) // retries without delay for tests
 		data := []byte("{}")
 
 		ctx := testutils.ContextWithLogger(t)
@@ -328,7 +331,7 @@ func TestUpsert(t *testing.T) {
 		url, _ := url.Parse(server.URL) //nolint:errcheck
 
 		client := buckets.NewClient(rest.NewClient(url, server.Client()),
-			buckets.WithRetrySettings(5, 0, 2*time.Minute)) // retries without delay for tests
+			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration)) // retries without delay for tests
 
 		ctx := testutils.ContextWithLogger(t)
 
@@ -372,7 +375,7 @@ func TestUpsert(t *testing.T) {
 		defer server.Close()
 
 		client := buckets.NewClient(rest.NewClient(server.URL(), server.Client()),
-			buckets.WithRetrySettings(5, 0, 2*time.Minute)) // retries without delay for tests
+			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration)) // retries without delay for tests
 		data := []byte("{}")
 
 		ctx := testutils.ContextWithLogger(t)
@@ -452,7 +455,7 @@ func TestUpsert(t *testing.T) {
 		defer server.Close()
 
 		client := buckets.NewClient(rest.NewClient(server.URL(), server.Client()),
-			buckets.WithRetrySettings(5, 0, 2*time.Minute)) // retries without delay for tests
+			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration)) // retries without delay for tests
 		data := []byte("{}")
 
 		ctx := testutils.ContextWithLogger(t)
@@ -508,7 +511,7 @@ func TestUpsert(t *testing.T) {
 		defer server.Close()
 
 		client := buckets.NewClient(rest.NewClient(server.URL(), server.Client()),
-			buckets.WithRetrySettings(5, 0, 2*time.Minute)) // retries without delay for tests
+			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration)) // retries without delay for tests
 		data := []byte("{}")
 
 		ctx := testutils.ContextWithLogger(t)
@@ -567,7 +570,7 @@ func TestUpsert(t *testing.T) {
 
 		client := buckets.NewClient(
 			rest.NewClient(server.URL(), server.Client()),
-			buckets.WithRetrySettings(5, 0, time.Minute))
+			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration))
 		data := []byte("{}")
 
 		ctx := testutils.ContextWithLogger(t)
@@ -619,7 +622,7 @@ func TestUpsert(t *testing.T) {
 
 		client := buckets.NewClient(
 			rest.NewClient(server.URL(), server.Client()),
-			buckets.WithRetrySettings(5, 0, time.Minute))
+			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration))
 		data := []byte("{}")
 
 		ctx := testutils.ContextWithLogger(t)
@@ -698,7 +701,7 @@ func TestUpsert(t *testing.T) {
 		defer server.Close()
 
 		client := buckets.NewClient(rest.NewClient(server.URL(), server.Client()),
-			buckets.WithRetrySettings(5, 0, 2*time.Minute)) // retries without delay for tests
+			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration)) // retries without delay for tests
 		data := []byte(activeBucketResponse)
 
 		ctx := testutils.ContextWithLogger(t)
@@ -793,7 +796,7 @@ func TestUpsert(t *testing.T) {
 		defer server.Close()
 
 		client := buckets.NewClient(rest.NewClient(server.URL(), server.Client()),
-			buckets.WithRetrySettings(5, 0, 2*time.Minute)) // retries without delay for tests
+			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration)) // retries without delay for tests
 		data := []byte("{}")
 
 		ctx := testutils.ContextWithLogger(t)
@@ -843,7 +846,7 @@ func TestDelete(t *testing.T) {
 		defer server.Close()
 
 		client := buckets.NewClient(rest.NewClient(server.URL(), server.Client()),
-			buckets.WithRetrySettings(5, 0, 2*time.Minute)) // retries without delay for tests
+			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration)) // retries without delay for tests
 
 		ctx := testutils.ContextWithLogger(t)
 
@@ -869,7 +872,7 @@ func TestDelete(t *testing.T) {
 		defer server.Close()
 
 		client := buckets.NewClient(rest.NewClient(server.URL(), server.Client()),
-			buckets.WithRetrySettings(5, 0, 2*time.Minute)) // retries without delay for tests
+			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration)) // retries without delay for tests
 
 		ctx := testutils.ContextWithLogger(t)
 
@@ -940,7 +943,7 @@ func TestCreate(t *testing.T) {
 		defer server.Close()
 
 		client := buckets.NewClient(rest.NewClient(server.URL(), server.Client()),
-			buckets.WithRetrySettings(5, 0, 2*time.Minute)) // retries without delay for tests
+			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration)) // retries without delay for tests
 
 		ctx := testutils.ContextWithLogger(t)
 
@@ -976,7 +979,7 @@ func TestCreate(t *testing.T) {
 		url, _ := url.Parse(server.URL) //nolint:errcheck
 
 		client := buckets.NewClient(rest.NewClient(url, server.Client()),
-			buckets.WithRetrySettings(5, 0, 2*time.Minute)) // retries without delay for tests
+			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration)) // retries without delay for tests
 
 		ctx := testutils.ContextWithLogger(t)
 
@@ -1014,7 +1017,7 @@ func TestCreate(t *testing.T) {
 		defer server.Close()
 
 		client := buckets.NewClient(rest.NewClient(server.URL(), server.Client()),
-			buckets.WithRetrySettings(5, 0, 2*time.Minute)) // retries without delay for tests
+			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration)) // retries without delay for tests
 
 		ctx := testutils.ContextWithLogger(t)
 
@@ -1059,7 +1062,7 @@ func TestUpdate(t *testing.T) {
 		defer server.Close()
 
 		client := buckets.NewClient(rest.NewClient(server.URL(), &http.Client{}),
-			buckets.WithRetrySettings(5, 0, 2*time.Minute)) // retries without delay for tests
+			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration)) // retries without delay for tests
 		data := []byte("{}")
 
 		ctx := testutils.ContextWithLogger(t)
@@ -1127,7 +1130,7 @@ func TestUpdate(t *testing.T) {
 		defer server.Close()
 
 		client := buckets.NewClient(rest.NewClient(server.URL(), &http.Client{}),
-			buckets.WithRetrySettings(5, 0, 2*time.Minute)) // retries without delay for tests
+			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration)) // retries without delay for tests
 		data := []byte("{}")
 
 		ctx := testutils.ContextWithLogger(t)
@@ -1161,7 +1164,7 @@ func TestUpdate(t *testing.T) {
 		defer server.Close()
 
 		client := buckets.NewClient(rest.NewClient(server.URL(), server.Client()),
-			buckets.WithRetrySettings(5, 0, 2*time.Minute)) // retries without delay for tests
+			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration)) // retries without delay for tests
 		data := []byte(`{
 	 "bucketName": "bucket name",
 	 "table": "metrics",
@@ -1220,7 +1223,7 @@ func TestUpdate(t *testing.T) {
 
 		client := buckets.NewClient(
 			rest.NewClient(server.URL(), server.Client()),
-			buckets.WithRetrySettings(5, 0, time.Minute))
+			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration))
 		data := []byte("{}")
 
 		ctx := testutils.ContextWithLogger(t)
@@ -1248,7 +1251,7 @@ func TestUpdate(t *testing.T) {
 		defer server.Close()
 
 		client := buckets.NewClient(rest.NewClient(server.URL(), &http.Client{}),
-			buckets.WithRetrySettings(5, 0, 2*time.Minute)) // retries without delay for tests
+			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration)) // retries without delay for tests
 		data := []byte("{}")
 
 		ctx := testutils.ContextWithLogger(t)
@@ -1286,7 +1289,7 @@ func TestUpdate(t *testing.T) {
 		defer server.Close()
 
 		client := buckets.NewClient(rest.NewClient(server.URL(), &http.Client{}),
-			buckets.WithRetrySettings(5, 0, 2*time.Minute)) // retries without delay for tests
+			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration)) // retries without delay for tests
 		data := []byte("{}")
 
 		ctx := testutils.ContextWithLogger(t)
@@ -1330,7 +1333,7 @@ func TestUpdate(t *testing.T) {
 
 		u, _ := url.Parse(server.URL)
 		client := buckets.NewClient(rest.NewClient(u, &http.Client{}),
-			buckets.WithRetrySettings(5, 0, 2*time.Minute)) // retries without delay for tests
+			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration)) // retries without delay for tests
 		data := []byte("{}")
 
 		ctx := testutils.ContextWithLogger(t)
@@ -1371,7 +1374,7 @@ func TestUpdate(t *testing.T) {
 
 		u, _ := url.Parse(server.URL)
 		client := buckets.NewClient(rest.NewClient(u, &http.Client{}),
-			buckets.WithRetrySettings(5, 0, 0)) // maxWaitDuration should time out immediately
+			buckets.WithRetrySettings(0, 0)) // maxWaitDuration should time out immediately
 		data := []byte("{}")
 
 		ctx := testutils.ContextWithLogger(t)
@@ -1423,7 +1426,7 @@ func TestDecodingBucketResponses(t *testing.T) {
 		defer server.Close()
 
 		client := buckets.NewClient(rest.NewClient(server.URL(), server.Client()),
-			buckets.WithRetrySettings(5, 0, 2*time.Minute)) // retries without delay for tests
+			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration)) // retries without delay for tests
 
 		ctx := testutils.ContextWithLogger(t)
 
@@ -1460,7 +1463,7 @@ func TestDecodingBucketResponses(t *testing.T) {
 		defer server.Close()
 
 		client := buckets.NewClient(rest.NewClient(server.URL(), server.Client()),
-			buckets.WithRetrySettings(5, 0, 2*time.Minute)) // retries without delay for tests
+			buckets.WithRetrySettings(bucketDurationBetweenTries, bucketMaxWaitDuration)) // retries without delay for tests
 
 		ctx := testutils.ContextWithLogger(t)
 

--- a/clients/factory.go
+++ b/clients/factory.go
@@ -195,12 +195,12 @@ func (f factory) SLOClient(ctx context.Context) (*slo.Client, error) {
 
 // BucketClientWithRetrySettings creates and returns a new instance of buckets.Client with non-default retry settings.
 // For details about how retry settings are used, see buckets.WithRetrySettings.
-func (f factory) BucketClientWithRetrySettings(ctx context.Context, maxRetries int, durationBetweenTries time.Duration, maxWaitDuration time.Duration) (*buckets.Client, error) {
+func (f factory) BucketClientWithRetrySettings(ctx context.Context, durationBetweenTries time.Duration, maxWaitDuration time.Duration) (*buckets.Client, error) {
 	restClient, err := f.CreatePlatformClient(ctx)
 	if err != nil {
 		return nil, err
 	}
-	return buckets.NewClient(restClient, buckets.WithRetrySettings(maxRetries, durationBetweenTries, maxWaitDuration)), nil
+	return buckets.NewClient(restClient, buckets.WithRetrySettings(durationBetweenTries, maxWaitDuration)), nil
 }
 
 // OpenPipelineClient creates and returns a new instance of openpipeline.Client for interacting with the openPipeline API.


### PR DESCRIPTION
This PR removes the unused `maxRetries` from buckets client retry settings.