### PR TITLE
refactor: Bucket client logs should include bucket name

### DIFF
--- a/clients/buckets/bucket.go
+++ b/clients/buckets/bucket.go
@@ -205,7 +205,7 @@ type DeletingBucketErr struct {
 
 // Error returns a string representation of the DeletingBucketErr.
 func (d DeletingBucketErr) Error() string {
-	return fmt.Sprintf("cannot bucket '%s' as it is currently being deleted", d.BucketName)
+	return fmt.Sprintf("cannot update bucket '%s' as it is currently being deleted", d.BucketName)
 }
 
 // Update attempts to update a bucket's data using the provided apiClient. It employs a retry mechanism

--- a/clients/buckets/bucket_test.go
+++ b/clients/buckets/bucket_test.go
@@ -1263,7 +1263,6 @@ func TestUpdate(t *testing.T) {
 		var apiError api.APIError
 		assert.ErrorAs(t, err, &apiError)
 		assert.Equal(t, http.StatusForbidden, apiError.StatusCode)
-
 	})
 
 	t.Run("Update fails because bucket is being deleted already", func(t *testing.T) {
@@ -1296,8 +1295,8 @@ func TestUpdate(t *testing.T) {
 		ctx := testutils.ContextWithLogger(t)
 
 		_, err := client.Update(ctx, "bucket name", data)
-		assert.ErrorIs(t, err, buckets.DeletingBucketErr)
-
+		deletingBucketErr := buckets.DeletingBucketErr{}
+		assert.ErrorAs(t, err, &deletingBucketErr)
 	})
 
 	t.Run("Update fails at first, but succeeds after retry", func(t *testing.T) {


### PR DESCRIPTION
This PR ensures that all log messages generated by the buckets client include the bucket name.