### PR TITLE
fix: Add `golangci_lint_version` to pin version

### DIFF
--- a/.github/workflows/pr-static-code-analysis.yml
+++ b/.github/workflows/pr-static-code-analysis.yml
@@ -36,3 +36,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-check
+          golangci_lint_version: "v1.64.8"


### PR DESCRIPTION
This PR introduces a pined version for golangci_lint.