### PR TITLE
fix(account): Revert `page` and `pageSize` to `integer`

### DIFF
--- a/gen/account_management/api_service_user_management.go
+++ b/gen/account_management/api_service_user_management.go
@@ -328,19 +328,19 @@ type ApiGetServiceUsersFromAccountRequest struct {
 	ctx         context.Context
 	ApiService  *ServiceUserManagementAPIService
 	accountUuid string
-	page        *int
-	pageSize    *int
+	page        *int32
+	pageSize    *int32
 	pageKey     *string
 }
 
 // The number of the requested page. Can be increased as long as **nextPageKey** is available in the response.
-func (r ApiGetServiceUsersFromAccountRequest) Page(page int) ApiGetServiceUsersFromAccountRequest {
+func (r ApiGetServiceUsersFromAccountRequest) Page(page int32) ApiGetServiceUsersFromAccountRequest {
 	r.page = &page
 	return r
 }
 
 // Defines the requested number of entries for the next page.
-func (r ApiGetServiceUsersFromAccountRequest) PageSize(pageSize int) ApiGetServiceUsersFromAccountRequest {
+func (r ApiGetServiceUsersFromAccountRequest) PageSize(pageSize int32) ApiGetServiceUsersFromAccountRequest {
 	r.pageSize = &pageSize
 	return r
 }

--- a/gen/specs/account_management/spec_formatted_fixed.json
+++ b/gen/specs/account_management/spec_formatted_fixed.json
@@ -2951,7 +2951,7 @@
                         "in": "query",
                         "description": "The number of the requested page. Can be increased as long as **nextPageKey** is available in the response.",
                         "schema": {
-                            "type": "int"
+                            "type": "integer"
                         }
                     },
                     {
@@ -2960,7 +2960,7 @@
                         "in": "query",
                         "description": "Defines the requested number of entries for the next page.",
                         "schema": {
-                            "type": "int"
+                            "type": "integer"
                         }
                     },
                     {


### PR DESCRIPTION
This PR  reverts `page` and `pageSize` to `integer` for GET `/iam/v1/accounts/{accountUuid}/service-users` in the fixed spec and includes the re-generated code for service user management.

While using `int` results in nicer generated code, it does not conform to the OpenAPI specification. Instead, ideally the openapi-generator should map `integer` to `int` for golang if not other constraints are present. This is requested in https://github.com/OpenAPITools/openapi-generator/issues/3055, but has not been implemented yet.
