### PR TITLE
fix(account): Add return type to `func (r ApiGetServiceUserRequest) Execute()`

### DIFF
--- a/gen/account_management/api_service_user_management.go
+++ b/gen/account_management/api_service_user_management.go
@@ -237,7 +237,7 @@ type ApiGetServiceUserRequest struct {
 	userUuid    string
 }
 
-func (r ApiGetServiceUserRequest) Execute() (*http.Response, error) {
+func (r ApiGetServiceUserRequest) Execute() (*ExternalServiceUserWithGroupUuidDto, *http.Response, error) {
 	return r.ApiService.GetServiceUserExecute(r)
 }
 
@@ -259,16 +259,19 @@ func (a *ServiceUserManagementAPIService) GetServiceUser(ctx context.Context, ac
 }
 
 // Execute executes the request
-func (a *ServiceUserManagementAPIService) GetServiceUserExecute(r ApiGetServiceUserRequest) (*http.Response, error) {
+//
+//	@return ExternalServiceUserWithGroupUuidDto
+func (a *ServiceUserManagementAPIService) GetServiceUserExecute(r ApiGetServiceUserRequest) (*ExternalServiceUserWithGroupUuidDto, *http.Response, error) {
 	var (
-		localVarHTTPMethod = http.MethodGet
-		localVarPostBody   interface{}
-		formFiles          []formFile
+		localVarHTTPMethod  = http.MethodGet
+		localVarPostBody    interface{}
+		formFiles           []formFile
+		localVarReturnValue *ExternalServiceUserWithGroupUuidDto
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ServiceUserManagementAPIService.GetServiceUser")
 	if err != nil {
-		return nil, &GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/iam/v1/accounts/{accountUuid}/service-users/{userUuid}"
@@ -289,7 +292,7 @@ func (a *ServiceUserManagementAPIService) GetServiceUserExecute(r ApiGetServiceU
 	}
 
 	// to determine the Accept header
-	localVarHTTPHeaderAccepts := []string{}
+	localVarHTTPHeaderAccepts := []string{"application/json"}
 
 	// set Accept header
 	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
@@ -298,19 +301,19 @@ func (a *ServiceUserManagementAPIService) GetServiceUserExecute(r ApiGetServiceU
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {
-		return nil, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarHTTPResponse, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := io.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = io.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		return localVarHTTPResponse, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -318,10 +321,19 @@ func (a *ServiceUserManagementAPIService) GetServiceUserExecute(r ApiGetServiceU
 			body:  localVarBody,
 			error: localVarHTTPResponse.Status,
 		}
-		return localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, nil
+	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	if err != nil {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: err.Error(),
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiGetServiceUsersFromAccountRequest struct {

--- a/gen/specs/account_management/spec_formatted_fixed.json
+++ b/gen/specs/account_management/spec_formatted_fixed.json
@@ -3069,7 +3069,14 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Success. The user has been fetched."
+                        "description": "Success. The user has been fetched.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ExternalServiceUserWithGroupUuidDto"
+                                }
+                            }
+                        }
                     }
                 },
                 "tags": [


### PR DESCRIPTION
This PR manually updates the spec to add a return type for GET `/iam/v1/accounts/{accountUuid}/service-users/{userUuid}` and  updates the generated code.

The return type was added in response to what the API actually returns.