### PR TITLE
ci: use golangci-lint and remove double lint reporting

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -91,7 +91,7 @@ jobs:
         with:
           install-mode: 'goinstall' # install mode goinstall in order to use hashes for the version
           version: eabc2638a66daf5bb6c6fb052a32fa3ef7b6600d #v2.1.6
-          args: '--output.checkstyle.path=lint-report.xml'
+          args: '--output.checkstyle.path=lint-report.xml --issues-exit-code=0' # if issues are found, don't exit with "1". Sonar decides if it fails or not
 
       - name: ⬆️ Archive lint results
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -87,14 +87,11 @@ jobs:
         run: make vet
 
       - name: 🔎 golangci-lint
-        uses: reviewdog/action-golangci-lint@f9bba13753278f6a73b27a56a3ffb1bfda90ed71 #v2.8.0
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 #v8.0.0
         with:
-          go_version_file: go.mod
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          reporter: github-pr-check
-          golangci_lint_version: v2.0.2
-          # the name has to be as the same as the one specified in "sonar-project.properties" and in the upload artifact step
-          golangci_lint_flags: "--output.checkstyle.path=lint-report.xml"
+          install-mode: 'goinstall' # install mode goinstall in order to use hashes for the version
+          version: eabc2638a66daf5bb6c6fb052a32fa3ef7b6600d #v2.1.6
+          args: '--output.checkstyle.path=lint-report.xml'
 
       - name: ⬆️ Archive lint results
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2


### PR DESCRIPTION
#### **Why** this PR?
Regarding golangci-lint:
The golangci-lint action is from the maintainers of golangci-lint; it's the suggested way to use golangci-lint, and because of some incidents in the past, Reviewdog should not be used.

Regarding reporting:
Because Sonar does its reporting, we don't need our lint action to report (and fail) an additional time. Therefore, it's enough if the lint report is generated, which is everything Sonar needs. This also adds the ability to ignore specific errors that are reported not to occur again, once ignored.

#### **What** has changed?
- Reviewdog is now removed, and the golangci-lint action is used instead.
- The double reporting is gone, and Sonar will only be reporting.

#### **How** does it do it?
- Using the golangci-lint action.
- Adding an argument not to fail the pipeline if there are any errors.
- Removing the GitHub token from it, as we don't need the additional reporting tools.

#### How is it **tested**?
The lint report is generated. An additional commit with linting errors showed that the action did not fail, and Sonar correctly detected it and failed the pipeline.

#### How does it affect **users**?
Doesn't affect users