### PR TITLE
feat: support custom retry delay and amount for rest client calls

### DIFF
--- a/internal/pointer/pointer.go
+++ b/internal/pointer/pointer.go
@@ -1,0 +1,19 @@
+// @license
+// Copyright 2025 Dynatrace LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pointer
+
+func Pointer[T any](t T) *T {
+	return &t
+}


### PR DESCRIPTION
#### What this PR does / Why we need it:
Specific clients in Monaco CLI, like settings and config clients, have different retry logic. If the core retry logic should be used, the retry options for CRUD calls need to be extended. Therefore, CRUD requests now accept a custom delay and max retry amount, which is preferred over the client-set one.

#### Special notes for your reviewer:
Should we create a follow-up to move the request options into a struct? Note that the `RequestOptions` struct can't be reused because we must differentiate between empty value and nil (for example, zero retries or zero delay). Changing it to a struct also means a breaking change for the Monaco CLI (not for Terraform, as this is not used on their side).

#### Does this PR introduce a user-facing change?
- No breaking change for consumers of the lib
- Retry delay and max retry amount can now be set on CRUD operations