### PR TITLE
feat(clients): Allows settings custom http headers for client factory

### DIFF
--- a/clients/factory.go
+++ b/clients/factory.go
@@ -67,6 +67,7 @@ type factory struct {
 	concurrentRequestLimit int                       // The number of allowed concurrent requests
 	rateLimiterEnabled     bool                      // Enables rate limiter for clients
 	retryOptions           *rest.RetryOptions        // The retry strategy
+	customHeaders          map[string]string         // Custom HTTP headers
 }
 
 // WithOAuthCredentials sets the OAuth2 client credentials configuration for the factory.
@@ -128,6 +129,12 @@ func (f factory) WithRateLimiter(enabled bool) factory {
 // WithRetryOptions sets the RetryOptions for the underlying rest/http clients.
 func (f factory) WithRetryOptions(retryOptions *rest.RetryOptions) factory {
 	f.retryOptions = retryOptions
+	return f
+}
+
+// WithCustomHeaders sets the custom headers to be set for the underlying rest/http clients
+func (f factory) WithCustomHeaders(headers map[string]string) factory {
+	f.customHeaders = headers
 	return f
 }
 
@@ -249,6 +256,9 @@ func (f factory) createRestClient(u string, httpClient *http.Client) (*rest.Clie
 	restClient := rest.NewClient(parsedURL, httpClient, opts...)
 	if f.userAgent != "" {
 		restClient.SetHeader("User-Agent", f.userAgent)
+	}
+	for headerKey, headerValue := range f.customHeaders {
+		restClient.SetHeader(headerKey, headerValue)
 	}
 
 	return restClient, nil


### PR DESCRIPTION
#### **Why** this PR?
We want to have the option in Monaco to add  custom HTTP headers to requests.

#### **What** has changed?
Adds a map of customHeaders to the factory struct. Adds `WithCustomHeaders` function. 

#### **How** does it do it?
Sets headers, when creating REST clients.

#### How is it **tested**?
No tests added yet. I'd like to test headers set for created REST client but they are private. I don't want to expose them just for the test. Do you have ideas?

#### How does it affect **users**?
Allows consumers of the library to add their custom HTTP headers to requests.