### PR TITLE
test: Introduce end-to-end tests

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -1,0 +1,47 @@
+name: End-to-end tests
+on:
+  push:
+    branches:
+      - main
+  schedule:
+   - cron: '0 0 * * *' # nightly build ensure E2E tests run daily and catch any breaking API changes
+  pull_request_target:
+    types:
+      - labeled
+
+jobs:
+  integration-test:
+    name: 🌍 Integration tests
+    if: github.event.action != 'labeled' || github.event.label.name == 'run-e2e-test'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+    steps:
+    - name: Checkout # nosemgrep
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+      with:
+        ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+
+    - name: Set up Go 1.x
+      uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 #v5.5.0
+      with:
+        go-version-file: go.mod
+
+    - name: Install gotestsum
+      run: go install gotest.tools/gotestsum@3f7ff0ec4aeb6f95f5d67c998b71f272aa8a8b41 #v1.12.1
+
+    - name: Generate mocks
+      run:  go generate ./...
+
+    - name: 🌎 Integration test
+      run: gotestsum --format testdox --format-icons hivis -- -v -race -tags=e2e -timeout=30m  ./...
+      env:
+        CLASSIC_URL: ${{ secrets.CLASSIC_URL }}
+        PLATFORM_URL: ${{ secrets.PLATFORM_URL }}
+        API_TOKEN: ${{ secrets.API_TOKEN }}
+        PLATFORM_TOKEN: ${{ secrets.PLATFORM_TOKEN }}
+        OAUTH_CLIENT_ID: ${{ secrets.OAUTH_CLIENT_ID }}
+        OAUTH_CLIENT_SECRET: ${{ secrets.OAUTH_CLIENT_SECRET }}
+        OAUTH_TOKEN_ENDPOINT: ${{ secrets.OAUTH_TOKEN_ENDPOINT }}

--- a/api/auth/auth_e2e_test.go
+++ b/api/auth/auth_e2e_test.go
@@ -1,0 +1,142 @@
+//go:build e2e
+
+/*
+ * @license
+ * Copyright 2025 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package auth
+
+import (
+	"net/http"
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2/clientcredentials"
+)
+
+func TestNewApiTokenBasedClient_ValidToken(t *testing.T) {
+	t.Parallel()
+
+	apiToken := os.Getenv("API_TOKEN")
+	classicUrl := os.Getenv("CLASSIC_URL")
+
+	client := NewApiTokenBasedClient(t.Context(), apiToken)
+
+	targetUrl, err := url.JoinPath(classicUrl, "/api/v1/config/clusterversion")
+	require.NoError(t, err)
+
+	resp, err := client.Get(targetUrl)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestNewApiTokenBasedClient_InvalidToken(t *testing.T) {
+	t.Parallel()
+
+	apiToken := "some-invalid-token"
+	classicUrl := os.Getenv("CLASSIC_URL")
+
+	client := NewApiTokenBasedClient(t.Context(), apiToken)
+
+	targetUrl, err := url.JoinPath(classicUrl, "/api/v1/config/clusterversion")
+	require.NoError(t, err)
+
+	resp, err := client.Get(targetUrl)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+func TestNewPlatformTokenClient_ValidToken(t *testing.T) {
+	t.Parallel()
+
+	platformToken := os.Getenv("PLATFORM_TOKEN")
+	platformUrl := os.Getenv("PLATFORM_URL")
+
+	client := NewPlatformTokenClient(t.Context(), platformToken)
+
+	targetUrl, err := url.JoinPath(platformUrl, "/platform/management/v1/environment")
+	require.NoError(t, err)
+
+	resp, err := client.Get(targetUrl)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestNewPlatformTokenClient_InvalidToken(t *testing.T) {
+	t.Parallel()
+
+	platformToken := "some-invalid-token"
+	platformUrl := os.Getenv("PLATFORM_URL")
+
+	client := NewPlatformTokenClient(t.Context(), platformToken)
+
+	targetUrl, err := url.JoinPath(platformUrl, "/platform/management/v1/environment")
+	require.NoError(t, err)
+
+	resp, err := client.Get(targetUrl)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+func TestNewOAuthClient_ValidToken(t *testing.T) {
+	t.Parallel()
+
+	credentials := clientcredentials.Config{
+		TokenURL:     os.Getenv("OAUTH_TOKEN_URL"),
+		ClientID:     os.Getenv("OAUTH_CLIENT_ID"),
+		ClientSecret: os.Getenv("OAUTH_CLIENT_SECRET"),
+	}
+	platformUrl := os.Getenv("PLATFORM_URL")
+
+	client := NewOAuthBasedClient(t.Context(), &credentials)
+
+	targetUrl, err := url.JoinPath(platformUrl, "/platform/management/v1/environment")
+	require.NoError(t, err)
+
+	resp, err := client.Get(targetUrl)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestNewOAuthClient_InvalidToken(t *testing.T) {
+	t.Parallel()
+
+	credentials := clientcredentials.Config{
+		TokenURL:     os.Getenv("OAUTH_TOKEN_URL"),
+		ClientID:     os.Getenv("OAUTH_CLIENT_ID"),
+		ClientSecret: "invalid-token",
+	}
+	platformUrl := os.Getenv("PLATFORM_URL")
+
+	client := NewOAuthBasedClient(t.Context(), &credentials)
+
+	targetUrl, err := url.JoinPath(platformUrl, "/platform/management/v1/environment")
+	require.NoError(t, err)
+
+	_, err = client.Get(targetUrl)
+	require.Error(t, err)
+}


### PR DESCRIPTION
#### **Why** this PR?
We currently do not have any tests that test the 'real' behavior of the core library. We would not notice that an authentication method is broken until a consumer uses the library and notices it. 

This PR changes that. We introduce e2e tests that are executed
* nightly
* on `main`
* on branches with the `run-e2e-test` label

I suggest the following rules:
* No e2e test folder - put the e2e tests in the same directory as the functionality.
* The `e2e` tests must include the `e2e` built tag

#### 🚨 Security considerations

Workflows with the `pull_request_target` are dangerous to use. 
They are executed in the context of the target repository; thus, an attacker could create a PR to read all secrets in our repository.
We mitigate this issue by requiring the `run-e2e-test` label.
This label can only be set by maintainers and must only be set on reviewed PRs.

I reused the same mechanism as we have in the [Monaco repository](https://github.com/Dynatrace/dynatrace-configuration-as-code).

Until this PR is discussed, no secrets will be set in this repository - just to be sure.

#### **What** has changed?
We now have e2e tests 🎉 

#### **How** does it do it?
* Secrets are passed in the workflow
* Secrets can be used in the tests

**Note**: Secrets are not yet defined in GitHub to first review for potential issues.

#### How is it **tested**?
It's about tests!

#### How does it affect **users**?
Users of the library can be more sure that it works 🎉 
