### PR TITLE
chore: Remove `reviewers` from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    reviewers:
-      - "Dynatrace/monaco-maintainers"
     commit-message:
       prefix: "chore"
       include: "scope"
@@ -13,8 +11,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    reviewers:
-      - "Dynatrace/monaco-maintainers"
     commit-message:
       prefix: "chore"
       include: "scope"


### PR DESCRIPTION
#### **Why** this PR?
`reviewers` is no longer supported in `.github/dependabot.yml` as `CODEOWNERS` is used instead as described in https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/

#### **What** has changed and **how** does it do it?
Removes both instances of `reviewers` from `.github/dependabot.yml`

#### How is it **tested**?
Not required

#### How does it affect **users**?
No effect

**Issue:** NOISSUE
