### PR TITLE
feat: forward context to classic client creation

### DIFF
--- a/clients/factory.go
+++ b/clients/factory.go
@@ -243,6 +243,11 @@ func (f factory) CreatePlatformClient(ctx context.Context) (*rest.Client, error)
 
 // CreateClassicClient creates a REST client configured for accessing classic APIs.
 func (f factory) CreateClassicClient() (*rest.Client, error) {
+	return f.CreateClassicClientWithContext(context.TODO())
+}
+
+// CreateClassicClientWithContext creates a REST client configured for accessing classic APIs with a given context.
+func (f factory) CreateClassicClientWithContext(ctx context.Context) (*rest.Client, error) {
 	if f.accessToken == "" {
 		return nil, ErrAccessTokenMissing
 	}
@@ -251,7 +256,7 @@ func (f factory) CreateClassicClient() (*rest.Client, error) {
 		return nil, ErrClassicURLMissing
 	}
 
-	return f.createRestClient(f.classicURL, auth.NewAPITokenClient(context.TODO(), f.accessToken))
+	return f.createRestClient(f.classicURL, auth.NewAPITokenClient(ctx, f.accessToken))
 }
 
 func (f factory) createRestClient(u string, httpClient *http.Client) (*rest.Client, error) {

--- a/clients/factory_test.go
+++ b/clients/factory_test.go
@@ -142,6 +142,10 @@ func TestClientMissingPlatformURL(t *testing.T) {
 	restClient, err = f.CreateClassicClient()
 	assert.NoError(t, err)
 	assert.NotNil(t, restClient)
+
+	restClient, err = f.CreateClassicClientWithContext(t.Context())
+	assert.NoError(t, err)
+	assert.NotNil(t, restClient)
 }
 
 func TestClientMissingOAuthCredentials(t *testing.T) {
@@ -186,6 +190,10 @@ func TestClientMissingOAuthCredentials(t *testing.T) {
 	assert.ErrorIs(t, err, ErrNoPlatformCredentialsProvided)
 
 	restClient, err = f.CreateClassicClient()
+	assert.NoError(t, err)
+	assert.NotNil(t, restClient)
+
+	restClient, err = f.CreateClassicClientWithContext(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, restClient)
 }
@@ -242,6 +250,10 @@ func TestClientPlatformURLParsingError(t *testing.T) {
 	restClient, err = f.CreateClassicClient()
 	assert.NoError(t, err)
 	assert.NotNil(t, restClient)
+
+	restClient, err = f.CreateClassicClientWithContext(t.Context())
+	assert.NoError(t, err)
+	assert.NotNil(t, restClient)
 }
 
 func TestClientMissingAccountURL(t *testing.T) {
@@ -296,6 +308,10 @@ func TestClientMissingAccountURL(t *testing.T) {
 	assert.NotNil(t, restClient)
 
 	restClient, err = f.CreateClassicClient()
+	assert.NoError(t, err)
+	assert.NotNil(t, restClient)
+
+	restClient, err = f.CreateClassicClientWithContext(t.Context())
 	assert.NoError(t, err)
 	assert.NotNil(t, restClient)
 }
@@ -355,6 +371,10 @@ func TestClientAccountURLParsingError(t *testing.T) {
 	restClient, err = f.CreateClassicClient()
 	assert.NoError(t, err)
 	assert.NotNil(t, restClient)
+
+	restClient, err = f.CreateClassicClientWithContext(t.Context())
+	assert.NoError(t, err)
+	assert.NotNil(t, restClient)
 }
 
 func TestClientMissingClassicURL(t *testing.T) {
@@ -410,6 +430,10 @@ func TestClientMissingClassicURL(t *testing.T) {
 	assert.NotNil(t, restClient)
 
 	restClient, err = f.CreateClassicClient()
+	assert.Nil(t, restClient)
+	assert.ErrorIs(t, err, ErrClassicURLMissing)
+
+	restClient, err = f.CreateClassicClientWithContext(t.Context())
 	assert.Nil(t, restClient)
 	assert.ErrorIs(t, err, ErrClassicURLMissing)
 }
@@ -469,6 +493,10 @@ func TestClientMissingAccessToken(t *testing.T) {
 	restClient, err = f.CreateClassicClient()
 	assert.Nil(t, restClient)
 	assert.ErrorIs(t, err, ErrAccessTokenMissing)
+
+	restClient, err = f.CreateClassicClientWithContext(t.Context())
+	assert.Nil(t, restClient)
+	assert.ErrorIs(t, err, ErrAccessTokenMissing)
 }
 
 func TestClientClassicURLParsingError(t *testing.T) {
@@ -525,6 +553,10 @@ func TestClientClassicURLParsingError(t *testing.T) {
 	assert.NotNil(t, restClient)
 
 	restClient, err = f.CreateClassicClient()
+	assert.Nil(t, restClient)
+	assert.ErrorContains(t, err, failedToParseURL)
+
+	restClient, err = f.CreateClassicClientWithContext(t.Context())
 	assert.Nil(t, restClient)
 	assert.ErrorContains(t, err, failedToParseURL)
 }
@@ -587,6 +619,25 @@ func TestCreateClassicClient(t *testing.T) {
 		WithClassicURL(apiServer.URL).
 		WithAccessToken("test-access-token").
 		CreateClassicClient()
+	assert.NoError(t, err)
+
+	resp, err := client.GET(t.Context(), "", rest.RequestOptions{})
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+}
+
+func TestCreateClassicClientWithContext(t *testing.T) {
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		assert.Equal(t, "Api-Token test-access-token", auth)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer apiServer.Close()
+
+	client, err := Factory().
+		WithClassicURL(apiServer.URL).
+		WithAccessToken("test-access-token").
+		CreateClassicClientWithContext(t.Context())
 	assert.NoError(t, err)
 
 	resp, err := client.GET(t.Context(), "", rest.RequestOptions{})


### PR DESCRIPTION
The context was not forwarded to the creation of the oauth2 client, which prevented us from overriding the client used in the oauth2 lib

#### **Why** this PR?
For some configurations, we need to override the HTTP client used. This is only possible by adding the custom client to the context, which is then later on used by the OAuth2 lib.

#### **What** has changed?
A new function was added that accepts a context when creating a classic client.
The old function wasn't touched as this would result in a breaking change and several adjustments in the Terraform provider.

#### **How** does it do it?
By adding a new function that accepts and forwards the context.

#### How is it **tested**?
New tests added for creating the client

#### How does it affect **users**?
It doesn't affect users but consumers of the lib. They can now override the http client by setting it in the context
```go
context.WithValue(ctx, oauth2.HTTPClient, &http.Client{
	Transport: &http.Transport{
		...
	},
	...
})
```