### PR TITLE
ci: ensure only repo-member's code is e2e-tested

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -12,7 +12,11 @@ on:
 jobs:
   integration-test:
     name: 🌍 Integration tests
-    if: github.event.action != 'labeled' || github.event.label.name == 'run-e2e-test'
+    # Verify that either the workflow is executed as part of the main-branch or the scheduled test,
+    # OR that the PR is labeled using the `run-e2e-test` label and the PR author is a member of the organization.
+    if: |
+      github.event.action != 'labeled'
+      || (github.event.label.name == 'run-e2e-test' && github.event.pull_request.author_association == 'MEMBER')
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION


#### **Why** this PR?
The e2e tests utilize `pull_request_target` to access the secrets for e2e tests. 

#### **What** has changed?

To ensure that this is safe, we force that the label `run-e2e-test` is set on a change before the test runs. For additional security, we now enforce that the author of the PR must be a member of the repository.

ref: omitted