### PR TITLE
feat(extensions): versions and active version endpoints

### DIFF
--- a/clients/extensions/client.go
+++ b/clients/extensions/client.go
@@ -29,10 +29,13 @@ import (
 const (
 	extensionsResourcePath           = "/platform/extensions/v2/extensions"
 	monitoringResourcePath           = "monitoring-configurations"
+	environmentConfigurationPath     = "environment-configuration"
 	extensionsResource               = "extensions"
 	monitoringConfigurationsResource = "monitoring-configurations"
+	environmentConfigurationResource = "environment-configuration"
 	urlCreationErrMsg                = "failed to construct URL"
 	extensionsPageSize               = 100
+	extensionVersionsPageSize        = 100
 	monitoringConfigurationsPageSize = 500
 )
 
@@ -88,6 +91,54 @@ func (c Client) listExtensionsPage(ctx context.Context, pageKey string) (string,
 	}
 
 	return processListResponse(resp, extensionsResource)
+}
+
+// ListExtensionVersions returns all installed versions of a given extension.
+func (c Client) ListExtensionVersions(ctx context.Context, extensionName string) (api.PagedListResponse, error) {
+	if extensionName == "" {
+		return nil, extensionNameValidationErr
+	}
+
+	var pagedListResponse api.PagedListResponse
+
+	nextPageKey := ""
+	for {
+		var listResponse api.ListResponse
+		var err error
+
+		nextPageKey, listResponse, err = c.listExtensionVersionsPage(ctx, extensionName, nextPageKey)
+		if err != nil {
+			return nil, err
+		}
+
+		pagedListResponse = append(pagedListResponse, listResponse)
+		if nextPageKey == "" {
+			break
+		}
+	}
+
+	return pagedListResponse, nil
+}
+
+func (c Client) listExtensionVersionsPage(ctx context.Context, extensionName string, pageKey string) (string, api.ListResponse, error) {
+	path, err := url.JoinPath(extensionsResourcePath, extensionName)
+	if err != nil {
+		return "", api.ListResponse{}, api.RuntimeError{Resource: extensionsResource, Identifier: extensionName, Reason: urlCreationErrMsg, Wrapped: err}
+	}
+
+	var ro rest.RequestOptions
+	if pageKey != "" {
+		ro.QueryParams = url.Values{"next-page-key": {pageKey}}
+	} else {
+		ro.QueryParams = url.Values{"page-size": {strconv.Itoa(extensionVersionsPageSize)}}
+	}
+
+	httpResp, err := c.restClient.GET(ctx, path, ro)
+	if err != nil {
+		return "", api.ListResponse{}, api.ClientError{Resource: extensionsResource, Identifier: extensionName, Operation: http.MethodGet, Wrapped: err}
+	}
+
+	return processListResponse(httpResp, extensionsResource)
 }
 
 // ListMonitoringConfigurations returns all monitoring configurations for a given extension.
@@ -170,6 +221,29 @@ func processListResponse(httpResponse *http.Response, resource string) (string, 
 			Objects: objects,
 		},
 		nil
+}
+
+// GetEnvironmentConfiguration returns the environment configuration for a given extension.
+func (c Client) GetEnvironmentConfiguration(ctx context.Context, extensionName string) (api.Response, error) {
+	if extensionName == "" {
+		return api.Response{}, extensionNameValidationErr
+	}
+
+	path, err := url.JoinPath(extensionsResourcePath, extensionName, environmentConfigurationPath)
+	if err != nil {
+		return api.Response{}, api.RuntimeError{Resource: environmentConfigurationResource, Identifier: extensionName, Reason: urlCreationErrMsg, Wrapped: err}
+	}
+
+	httpResp, err := c.restClient.GET(ctx, path, rest.RequestOptions{})
+	if err != nil {
+		return api.Response{}, api.ClientError{Resource: environmentConfigurationResource, Identifier: extensionName, Operation: http.MethodGet, Wrapped: err}
+	}
+
+	resp, err := api.NewResponseFromHTTPResponse(httpResp)
+	if err != nil {
+		return api.Response{}, api.ClientError{Resource: environmentConfigurationResource, Identifier: extensionName, Operation: http.MethodGet, Wrapped: err}
+	}
+	return resp, nil
 }
 
 // GetMonitoringConfiguration returns a specific monitoring configuration by extension name and configuration ID.

--- a/clients/extensions/client.go
+++ b/clients/extensions/client.go
@@ -99,46 +99,11 @@ func (c Client) ListExtensionVersions(ctx context.Context, extensionName string)
 		return nil, extensionNameValidationErr
 	}
 
-	var pagedListResponse api.PagedListResponse
-
-	nextPageKey := ""
-	for {
-		var listResponse api.ListResponse
-		var err error
-
-		nextPageKey, listResponse, err = c.listExtensionVersionsPage(ctx, extensionName, nextPageKey)
-		if err != nil {
-			return nil, err
-		}
-
-		pagedListResponse = append(pagedListResponse, listResponse)
-		if nextPageKey == "" {
-			break
-		}
-	}
-
-	return pagedListResponse, nil
-}
-
-func (c Client) listExtensionVersionsPage(ctx context.Context, extensionName string, pageKey string) (string, api.ListResponse, error) {
 	path, err := url.JoinPath(extensionsResourcePath, extensionName)
 	if err != nil {
-		return "", api.ListResponse{}, api.RuntimeError{Resource: extensionsResource, Identifier: extensionName, Reason: urlCreationErrMsg, Wrapped: err}
+		return nil, api.RuntimeError{Resource: extensionsResource, Identifier: extensionName, Reason: urlCreationErrMsg, Wrapped: err}
 	}
-
-	var ro rest.RequestOptions
-	if pageKey != "" {
-		ro.QueryParams = url.Values{"next-page-key": {pageKey}}
-	} else {
-		ro.QueryParams = url.Values{"page-size": {strconv.Itoa(extensionVersionsPageSize)}}
-	}
-
-	httpResp, err := c.restClient.GET(ctx, path, ro)
-	if err != nil {
-		return "", api.ListResponse{}, api.ClientError{Resource: extensionsResource, Identifier: extensionName, Operation: http.MethodGet, Wrapped: err}
-	}
-
-	return processListResponse(httpResp, extensionsResource)
+	return c.listAll(ctx, extensionName, path, extensionsResource, extensionVersionsPageSize)
 }
 
 // ListMonitoringConfigurations returns all monitoring configurations for a given extension.
@@ -147,14 +112,38 @@ func (c Client) ListMonitoringConfigurations(ctx context.Context, extensionName 
 		return nil, extensionNameValidationErr
 	}
 
-	var pagedListResponse api.PagedListResponse
+	path, err := url.JoinPath(extensionsResourcePath, extensionName, monitoringResourcePath)
+	if err != nil {
+		return nil, api.RuntimeError{Resource: monitoringConfigurationsResource, Identifier: extensionName, Reason: urlCreationErrMsg, Wrapped: err}
+	}
 
-	nextPageKey := ""
+	return c.listAll(ctx, extensionName, path, monitoringConfigurationsResource, monitoringConfigurationsPageSize)
+}
+
+// listAll is a helper method to list paged resources.
+// It takes care of paging through results until all pages have been retrieved and returns a combined PagedListResponse.
+func (c Client) listAll(ctx context.Context, extensionName string, path string, resourceName string, pageSize int) (api.PagedListResponse, error) {
+	var pagedListResponse api.PagedListResponse
+	var nextPageKey string
+
 	for {
 		var listResponse api.ListResponse
 		var err error
 
-		nextPageKey, listResponse, err = c.listMonitoringConfigurationsPage(ctx, extensionName, nextPageKey)
+		var ro rest.RequestOptions
+		if nextPageKey != "" {
+			ro.QueryParams = url.Values{"next-page-key": {nextPageKey}}
+		} else {
+			ro.QueryParams = url.Values{"page-size": {strconv.Itoa(pageSize)}}
+		}
+
+		httpResp, err := c.restClient.GET(ctx, path, ro)
+		if err != nil {
+			return nil, api.ClientError{Resource: resourceName, Identifier: extensionName, Operation: http.MethodGet, Wrapped: err}
+		}
+
+		nextPageKey, listResponse, err = processListResponse(httpResp, resourceName)
+
 		if err != nil {
 			return nil, err
 		}
@@ -164,29 +153,7 @@ func (c Client) ListMonitoringConfigurations(ctx context.Context, extensionName 
 			break
 		}
 	}
-
 	return pagedListResponse, nil
-}
-
-func (c Client) listMonitoringConfigurationsPage(ctx context.Context, extensionName string, pageKey string) (string, api.ListResponse, error) {
-	path, err := url.JoinPath(extensionsResourcePath, extensionName, monitoringResourcePath)
-	if err != nil {
-		return "", api.ListResponse{}, api.RuntimeError{Resource: monitoringConfigurationsResource, Identifier: extensionName, Reason: urlCreationErrMsg, Wrapped: err}
-	}
-
-	var ro rest.RequestOptions
-	if pageKey != "" {
-		ro.QueryParams = url.Values{"next-page-key": {pageKey}}
-	} else {
-		ro.QueryParams = url.Values{"page-size": {strconv.Itoa(monitoringConfigurationsPageSize)}}
-	}
-
-	httpResp, err := c.restClient.GET(ctx, path, ro)
-	if err != nil {
-		return "", api.ListResponse{}, api.ClientError{Resource: monitoringConfigurationsResource, Identifier: extensionName, Operation: http.MethodGet, Wrapped: err}
-	}
-
-	return processListResponse(httpResp, monitoringConfigurationsResource)
 }
 
 // processListResponse is shared by both list endpoints. It unmarshals the "nextPageKey" and "items" fields.

--- a/clients/extensions/client_test.go
+++ b/clients/extensions/client_test.go
@@ -149,6 +149,131 @@ func TestListExtensions(t *testing.T) {
 	})
 }
 
+func TestListExtensionVersions(t *testing.T) {
+	t.Run("successfully returns all versions across multiple pages", func(t *testing.T) {
+		apiResponse1 := `{
+  "totalCount": 2,
+  "nextPageKey": "key_for_next_page",
+  "pageSize": 100,
+  "items": [
+    {"extensionName": "com.dynatrace.extension.foo", "version": "1.0.0"}
+  ]
+}`
+		apiResponse2 := `{
+  "totalCount": 2,
+  "pageSize": 100,
+  "items": [
+    {"extensionName": "com.dynatrace.extension.foo", "version": "1.1.0"}
+  ]
+}`
+
+		responses := []testutils.ResponseDef{
+			{
+				GET: func(t *testing.T, req *http.Request) testutils.Response {
+					require.Equal(t, "/platform/extensions/v2/extensions/com.dynatrace.extension.foo", req.URL.Path)
+					require.Equal(t, "100", req.URL.Query().Get(pageSizeParam))
+					require.Equal(t, "", req.URL.Query().Get(nextPageKeyParam))
+					return testutils.Response{ResponseCode: http.StatusOK, ResponseBody: apiResponse1}
+				},
+			},
+			{
+				GET: func(t *testing.T, req *http.Request) testutils.Response {
+					require.Equal(t, "/platform/extensions/v2/extensions/com.dynatrace.extension.foo", req.URL.Path)
+					require.Equal(t, "key_for_next_page", req.URL.Query().Get(nextPageKeyParam))
+					require.Equal(t, "", req.URL.Query().Get(pageSizeParam))
+					return testutils.Response{ResponseCode: http.StatusOK, ResponseBody: apiResponse2}
+				},
+			},
+		}
+		server := testutils.NewHTTPTestServer(t, responses)
+		defer server.Close()
+
+		client := extensions.NewClient(rest.NewClient(server.URL(), server.Client()))
+
+		resp, err := client.ListExtensionVersions(t.Context(), "com.dynatrace.extension.foo")
+
+		assert.NoError(t, err)
+		assert.NotEmpty(t, resp)
+		assert.Len(t, resp, 2, "for each call one listResponse should be present")
+		assert.Len(t, resp.All(), 2, "two version objects in total should be downloaded")
+	})
+
+	t.Run("errors if called without extension name", func(t *testing.T) {
+		client := extensions.NewClient(&rest.Client{})
+
+		resp, err := client.ListExtensionVersions(t.Context(), "")
+
+		assert.Empty(t, resp)
+		assert.ErrorIs(t, err, api.ValidationError{Resource: "extensions", Field: "extension-name", Reason: "is empty"})
+	})
+
+	t.Run("errors if can't execute all calls successfully", func(t *testing.T) {
+		apiResponse1 := `{
+  "totalCount": 2,
+  "nextPageKey": "key_for_next_page",
+  "pageSize": 100,
+  "items": [
+    {"extensionName": "com.dynatrace.extension.foo", "version": "1.0.0"}
+  ]
+}`
+
+		responses := []testutils.ResponseDef{
+			{
+				GET: func(t *testing.T, _ *http.Request) testutils.Response {
+					return testutils.Response{ResponseCode: http.StatusOK, ResponseBody: apiResponse1}
+				},
+			},
+			{
+				GET: func(t *testing.T, _ *http.Request) testutils.Response {
+					return testutils.Response{ResponseCode: http.StatusInternalServerError, ResponseBody: "Some error message from the server"}
+				},
+			},
+		}
+		server := testutils.NewHTTPTestServer(t, responses)
+		defer server.Close()
+
+		client := extensions.NewClient(rest.NewClient(server.URL(), server.Client()))
+
+		resp, err := client.ListExtensionVersions(t.Context(), "com.dynatrace.extension.foo")
+
+		assert.Empty(t, resp)
+		var apiErr api.APIError
+		assert.ErrorAs(t, err, &apiErr)
+		assert.Equal(t, http.StatusInternalServerError, apiErr.StatusCode)
+	})
+
+	t.Run("errors if HTTP request fails", func(t *testing.T) {
+		server := testutils.NewHTTPTestServer(t, []testutils.ResponseDef{})
+		defer server.Close()
+
+		client := extensions.NewClient(rest.NewClient(server.URL(), server.FaultyClient()))
+
+		resp, err := client.ListExtensionVersions(t.Context(), "com.dynatrace.extension.foo")
+
+		assert.Empty(t, resp)
+		assert.ErrorAs(t, err, &api.ClientError{})
+	})
+
+	t.Run("errors if JSON unmarshalling fails", func(t *testing.T) {
+		responses := []testutils.ResponseDef{
+			{
+				GET: func(t *testing.T, _ *http.Request) testutils.Response {
+					return testutils.Response{ResponseCode: http.StatusOK, ResponseBody: `invalid json`}
+				},
+			},
+		}
+		server := testutils.NewHTTPTestServer(t, responses)
+		defer server.Close()
+
+		client := extensions.NewClient(rest.NewClient(server.URL(), server.Client()))
+
+		resp, err := client.ListExtensionVersions(t.Context(), "com.dynatrace.extension.foo")
+
+		assert.Empty(t, resp)
+		assert.ErrorAs(t, err, &api.RuntimeError{})
+	})
+}
+
 func TestListMonitoringConfigurations(t *testing.T) {
 	t.Run("successfully returns all monitoring configurations across multiple pages", func(t *testing.T) {
 		apiResponse1 := `{
@@ -268,6 +393,82 @@ func TestListMonitoringConfigurations(t *testing.T) {
 
 		assert.Empty(t, resp)
 		assert.ErrorAs(t, err, &api.RuntimeError{})
+	})
+}
+
+func TestGetEnvironmentConfiguration(t *testing.T) {
+	t.Run("successfully returns environment configuration", func(t *testing.T) {
+		getResponse := `{"version": "1.2.3"}`
+
+		responses := []testutils.ResponseDef{
+			{
+				GET: func(t *testing.T, req *http.Request) testutils.Response {
+					require.Equal(t, "/platform/extensions/v2/extensions/com.dynatrace.extension.foo/environment-configuration", req.URL.Path)
+					return testutils.Response{ResponseCode: http.StatusOK, ResponseBody: getResponse}
+				},
+			},
+		}
+		server := testutils.NewHTTPTestServer(t, responses)
+		defer server.Close()
+
+		client := extensions.NewClient(rest.NewClient(server.URL(), server.Client()))
+
+		resp, err := client.GetEnvironmentConfiguration(t.Context(), "com.dynatrace.extension.foo")
+
+		assert.NoError(t, err)
+		assert.NotEmpty(t, resp)
+		assert.Equal(t, getResponse, string(resp.Data))
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("errors if called without extension name", func(t *testing.T) {
+		client := extensions.NewClient(&rest.Client{})
+
+		resp, err := client.GetEnvironmentConfiguration(t.Context(), "")
+
+		assert.Empty(t, resp)
+		assert.ErrorIs(t, err, api.ValidationError{Resource: "extensions", Field: "extension-name", Reason: "is empty"})
+	})
+
+	t.Run("errors if extension doesn't exist on server", func(t *testing.T) {
+		errorResponse := `{
+  "error": {
+    "code": 404,
+    "message": "Extension 'com.dynatrace.extension.unknown' not found."
+  }
+}`
+
+		responses := []testutils.ResponseDef{
+			{
+				GET: func(t *testing.T, _ *http.Request) testutils.Response {
+					return testutils.Response{ResponseCode: http.StatusNotFound, ResponseBody: errorResponse}
+				},
+			},
+		}
+		server := testutils.NewHTTPTestServer(t, responses)
+		defer server.Close()
+
+		client := extensions.NewClient(rest.NewClient(server.URL(), server.Client()))
+
+		resp, err := client.GetEnvironmentConfiguration(t.Context(), "com.dynatrace.extension.unknown")
+
+		assert.Empty(t, resp)
+		var apiErr api.APIError
+		assert.ErrorAs(t, err, &apiErr)
+		assert.Equal(t, http.StatusNotFound, apiErr.StatusCode)
+		assert.Equal(t, errorResponse, string(apiErr.Body))
+	})
+
+	t.Run("errors if HTTP request fails", func(t *testing.T) {
+		server := testutils.NewHTTPTestServer(t, []testutils.ResponseDef{})
+		defer server.Close()
+
+		client := extensions.NewClient(rest.NewClient(server.URL(), server.FaultyClient()))
+
+		resp, err := client.GetEnvironmentConfiguration(t.Context(), "com.dynatrace.extension.foo")
+
+		assert.Empty(t, resp)
+		assert.ErrorAs(t, err, &api.ClientError{})
 	})
 }
 


### PR DESCRIPTION
#### **Why** this PR?
Because of new requirements for Terraform, we need the extension endpiont to return all installed versions and the active version (environment config) endpiont

#### **What** has changed?
Adds two calls for
- the active version `/extensions/{extension-name}/environment-configuration`
- the installed versions `/extensions/{extension-name}`

#### How is it **tested**?
New tests added

#### How does it affect **users**?
They can get the installed versions and the active version of an extension

**Issue:** CA-19280, CA-19281