### PR TITLE
fix: Clients should not customize retry options

### DIFF
--- a/api/rest/client_test.go
+++ b/api/rest/client_test.go
@@ -538,7 +538,7 @@ func TestClient_WithRateLimiting_HardLimitActuallyBlocks(t *testing.T) {
 	baseURL, _ := url.Parse(server.URL)
 	client := NewClient(baseURL, nil,
 		WithRateLimiter(), // default rate limiter with real clock
-		WithRetryOptions(&RetryOptions{MaxRetries: 1, ShouldRetryFunc: RetryIfTooManyRequests}),
+		WithRetryOptions(&RetryOptions{MaxRetries: 1, ShouldRetryFunc: RetryIfTooManyRequestsOrServiceUnavailable}),
 	)
 
 	before := time.Now()

--- a/api/rest/retry.go
+++ b/api/rest/retry.go
@@ -33,9 +33,9 @@ func RetryIfNotSuccess(resp *http.Response) bool {
 	return !(isStatusSuccess(resp.StatusCode))
 }
 
-// RetryIfTooManyRequests return true for responses with status code Too Many Requests (429).
-func RetryIfTooManyRequests(resp *http.Response) bool {
-	return resp.StatusCode == http.StatusTooManyRequests
+// RetryIfTooManyRequestsOrServiceUnavailable returns true for responses with status code Too Many Requests (429) or Service Unavailable (503).
+func RetryIfTooManyRequestsOrServiceUnavailable(resp *http.Response) bool {
+	return resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode == http.StatusServiceUnavailable
 }
 
 // RetryOnFailureExcept404 returns true for all failed responses except those with status not found.

--- a/clients/automation/automation.go
+++ b/clients/automation/automation.go
@@ -306,9 +306,6 @@ func (a Client) makeRequestWithAdminAccess(resourceType ResourceType, request fu
 	if resourceType == Workflows {
 		opts := rest.RequestOptions{
 			QueryParams: url.Values{"adminAccess": []string{"true"}},
-			CustomShouldRetryFunc: func(resp *http.Response) bool {
-				return rest.RetryIfNotSuccess(resp) && (resp.StatusCode != http.StatusForbidden)
-			},
 		}
 		resp, err := request(opts)
 		if err != nil {
@@ -348,17 +345,7 @@ func (a Client) Delete(ctx context.Context, resourceType ResourceType, id string
 	}
 
 	resp, err := a.makeRequestWithAdminAccess(resourceType, func(options rest.RequestOptions) (*http.Response, error) {
-		opts := rest.RequestOptions{
-			QueryParams: options.QueryParams,
-			CustomShouldRetryFunc: func(resp *http.Response) bool {
-				if options.CustomShouldRetryFunc == nil {
-					return rest.RetryOnFailureExcept404(resp)
-				}
-
-				return options.CustomShouldRetryFunc(resp) && rest.RetryOnFailureExcept404(resp)
-			},
-		}
-		return a.restClient.DELETE(ctx, path, opts)
+		return a.restClient.DELETE(ctx, path, options)
 	})
 
 	if err != nil {

--- a/clients/automation/automation_test.go
+++ b/clients/automation/automation_test.go
@@ -92,7 +92,7 @@ func TestAutomationClient_Get(t *testing.T) {
 		server := testutils.NewHTTPTestServer(t, responses)
 		defer server.Close()
 
-		client := automation.NewClient(rest.NewClient(server.URL(), server.Client(), rest.WithRetryOptions(&rest.RetryOptions{MaxRetries: 10, ShouldRetryFunc: rest.RetryIfTooManyRequests})))
+		client := automation.NewClient(rest.NewClient(server.URL(), server.Client(), rest.WithRetryOptions(&rest.RetryOptions{MaxRetries: 10, ShouldRetryFunc: rest.RetryIfTooManyRequestsOrServiceUnavailable})))
 
 		resp, err := client.Get(t.Context(), automation.Workflows, "91cc8988-2223-404a-a3f5-5f1a839ecd45")
 		assert.Zero(t, resp)

--- a/clients/automation/automation_test.go
+++ b/clients/automation/automation_test.go
@@ -76,6 +76,29 @@ func TestAutomationClient_Get(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	t.Run("GET - Invalid ID does not retry", func(t *testing.T) {
+
+		responses := []testutils.ResponseDef{
+			{
+				GET: func(t *testing.T, req *http.Request) testutils.Response {
+					return testutils.Response{
+						ResponseCode: http.StatusBadRequest,
+						ResponseBody: payload,
+					}
+				},
+			},
+		}
+
+		server := testutils.NewHTTPTestServer(t, responses)
+		defer server.Close()
+
+		client := automation.NewClient(rest.NewClient(server.URL(), server.Client(), rest.WithRetryOptions(&rest.RetryOptions{MaxRetries: 10, ShouldRetryFunc: rest.RetryIfTooManyRequests})))
+
+		resp, err := client.Get(t.Context(), automation.Workflows, "91cc8988-2223-404a-a3f5-5f1a839ecd45")
+		assert.Zero(t, resp)
+		assert.Error(t, err)
+	})
+
 	t.Run("GET - Unable to make HTTP call", func(t *testing.T) {
 
 		responses := []testutils.ResponseDef{}

--- a/clients/buckets/bucket.go
+++ b/clients/buckets/bucket.go
@@ -42,8 +42,7 @@ const (
 )
 
 var (
-	ErrBucketEmpty        = fmt.Errorf("bucketName must be non-empty")
-	defaultRequestOptions = rest.RequestOptions{CustomShouldRetryFunc: rest.RetryIfTooManyRequests}
+	ErrBucketEmpty = fmt.Errorf("bucketName must be non-empty")
 )
 
 type bucketResponse struct {
@@ -111,7 +110,7 @@ func (c Client) Get(ctx context.Context, bucketName string) (api.Response, error
 		return api.Response{}, fmt.Errorf(errMsgWithName, getOperation, bucketName, err)
 	}
 
-	resp, err := c.restClient.GET(ctx, path, defaultRequestOptions)
+	resp, err := c.restClient.GET(ctx, path, rest.RequestOptions{})
 	if err != nil {
 		return api.Response{}, fmt.Errorf(errMsgWithName, getOperation, bucketName, err)
 	}
@@ -134,7 +133,7 @@ func (c Client) Get(ctx context.Context, bucketName string) (api.Response, error
 //   - []Response: A slice of bucket Response containing the individual buckets resulting from the HTTP call, including status code and data.
 //   - error: An error if the HTTP call fails or another error happened.
 func (c Client) List(ctx context.Context) (ListResponse, error) {
-	resp, err := c.restClient.GET(ctx, endpointPath, defaultRequestOptions)
+	resp, err := c.restClient.GET(ctx, endpointPath, rest.RequestOptions{})
 	if err != nil {
 		return ListResponse{}, fmt.Errorf(errMsg, listOperation, err)
 	}
@@ -184,7 +183,7 @@ func (c Client) Create(ctx context.Context, bucketName string, data []byte) (api
 	if err := setBucketName(bucketName, &data); err != nil {
 		return api.Response{}, fmt.Errorf(errMsgWithName, createOperation, bucketName, fmt.Errorf("unable to set bucket name: %w", err))
 	}
-	r, err := c.restClient.POST(ctx, endpointPath, bytes.NewReader(data), defaultRequestOptions)
+	r, err := c.restClient.POST(ctx, endpointPath, bytes.NewReader(data), rest.RequestOptions{})
 	if err != nil {
 		return api.Response{}, fmt.Errorf(errMsgWithName, createOperation, bucketName, err)
 	}
@@ -216,7 +215,7 @@ func (c Client) Delete(ctx context.Context, bucketName string) (api.Response, er
 		return api.Response{}, fmt.Errorf(errMsgWithName, deleteOperation, bucketName, err)
 	}
 
-	resp, err := c.restClient.DELETE(ctx, path, defaultRequestOptions)
+	resp, err := c.restClient.DELETE(ctx, path, rest.RequestOptions{})
 
 	if err != nil {
 		return api.Response{}, fmt.Errorf(errMsgWithName, deleteOperation, bucketName, err)
@@ -291,8 +290,7 @@ func (c Client) Update(ctx context.Context, bucketName string, data []byte) (api
 	}
 
 	resp, err := c.restClient.PUT(ctx, path, bytes.NewReader(data), rest.RequestOptions{
-		QueryParams:           url.Values{"optimistic-locking-version": []string{strconv.Itoa(res.Version)}},
-		CustomShouldRetryFunc: defaultRequestOptions.CustomShouldRetryFunc,
+		QueryParams: url.Values{"optimistic-locking-version": []string{strconv.Itoa(res.Version)}},
 	})
 
 	if err != nil {

--- a/clients/documents/documents.go
+++ b/clients/documents/documents.go
@@ -372,8 +372,7 @@ func (c Client) delete(ctx context.Context, id string, version int) (api.Respons
 	}
 
 	r, err := c.restClient.DELETE(ctx, path, rest.RequestOptions{
-		QueryParams:           map[string][]string{optimisticLockingHeader: {strconv.Itoa(version)}},
-		CustomShouldRetryFunc: rest.RetryOnFailureExcept404,
+		QueryParams: map[string][]string{optimisticLockingHeader: {strconv.Itoa(version)}},
 	})
 	if err != nil {
 		return api.Response{}, fmt.Errorf(errMsgWithID, deleteOperation, id, err)

--- a/clients/segments/segments.go
+++ b/clients/segments/segments.go
@@ -45,8 +45,7 @@ type Client struct {
 func (c Client) List(ctx context.Context) (api.Response, error) {
 	path := basePath.String() + ":lean"
 	resp, err := c.restClient.GET(ctx, path, rest.RequestOptions{
-		CustomShouldRetryFunc: rest.RetryIfTooManyRequests,
-		QueryParams:           url.Values{"add-fields": []string{"EXTERNALID"}},
+		QueryParams: url.Values{"add-fields": []string{"EXTERNALID"}},
 	})
 
 	if err != nil {
@@ -85,8 +84,7 @@ func (c Client) Get(ctx context.Context, id string) (api.Response, error) {
 
 	path := basePath.JoinPath(id).String()
 	resp, err := c.restClient.GET(ctx, path, rest.RequestOptions{
-		CustomShouldRetryFunc: rest.RetryIfTooManyRequests,
-		QueryParams:           url.Values{"add-fields": []string{"INCLUDES", "VARIABLES", "EXTERNALID", "RESOURCECONTEXT"}},
+		QueryParams: url.Values{"add-fields": []string{"INCLUDES", "VARIABLES", "EXTERNALID", "RESOURCECONTEXT"}},
 	})
 	if err != nil {
 		return api.Response{}, api.ClientError{Resource: resource, Identifier: id, Operation: http.MethodGet, Wrapped: err}
@@ -96,7 +94,7 @@ func (c Client) Get(ctx context.Context, id string) (api.Response, error) {
 }
 
 func (c Client) Create(ctx context.Context, body []byte) (api.Response, error) {
-	resp, err := c.restClient.POST(ctx, endpointPath, bytes.NewReader(body), rest.RequestOptions{CustomShouldRetryFunc: rest.RetryIfTooManyRequests})
+	resp, err := c.restClient.POST(ctx, endpointPath, bytes.NewReader(body), rest.RequestOptions{})
 	if err != nil {
 		return api.Response{}, api.ClientError{Resource: resource, Operation: http.MethodPost, Wrapped: err}
 	}
@@ -136,8 +134,7 @@ func (c Client) Update(ctx context.Context, id string, body []byte) (api.Respons
 
 	path := basePath.JoinPath(id).String()
 	resp, err := c.restClient.PUT(ctx, path, bytes.NewReader(body), rest.RequestOptions{
-		CustomShouldRetryFunc: rest.RetryIfTooManyRequests,
-		QueryParams:           map[string][]string{"optimistic-locking-version": {strconv.Itoa(getResponse.Version)}}})
+		QueryParams: map[string][]string{"optimistic-locking-version": {strconv.Itoa(getResponse.Version)}}})
 	if err != nil {
 		return api.Response{}, api.ClientError{Resource: resource, Operation: http.MethodPut, Identifier: id, Wrapped: err}
 	}
@@ -151,7 +148,7 @@ func (c Client) Delete(ctx context.Context, id string) (api.Response, error) {
 	}
 
 	path := basePath.JoinPath(id).String()
-	resp, err := c.restClient.DELETE(ctx, path, rest.RequestOptions{CustomShouldRetryFunc: rest.RetryIfTooManyRequests})
+	resp, err := c.restClient.DELETE(ctx, path, rest.RequestOptions{})
 	if err != nil {
 		return api.Response{}, api.ClientError{Resource: resource, Operation: http.MethodDelete, Identifier: id, Wrapped: err}
 	}

--- a/clients/settings/permissions/permissions.go
+++ b/clients/settings/permissions/permissions.go
@@ -165,7 +165,6 @@ func (c *Client) delete(ctx context.Context, objectID string, accessorType strin
 
 func getRequestOptions(adminAccess bool) rest.RequestOptions {
 	return rest.RequestOptions{
-		CustomShouldRetryFunc: rest.RetryIfTooManyRequests,
-		QueryParams:           url.Values{"adminAccess": []string{strconv.FormatBool(adminAccess)}},
+		QueryParams: url.Values{"adminAccess": []string{strconv.FormatBool(adminAccess)}},
 	}
 }

--- a/clients/slo/slo.go
+++ b/clients/slo/slo.go
@@ -62,7 +62,7 @@ func (c *Client) List(ctx context.Context) (api.PagedListResponse, error) {
 }
 
 func listPage(ctx context.Context, c *Client, pageKey string) (string, api.ListResponse, error) {
-	ro := rest.RequestOptions{CustomShouldRetryFunc: rest.RetryIfTooManyRequests}
+	ro := rest.RequestOptions{}
 	if pageKey != "" {
 		ro.QueryParams = url.Values{"page-key": {pageKey}}
 	}
@@ -85,7 +85,7 @@ func (c *Client) Get(ctx context.Context, id string) (api.Response, error) {
 		return api.Response{}, fmt.Errorf(errMsgWithId, "get", id, err)
 	}
 
-	resp, err := c.restClient.GET(ctx, path, rest.RequestOptions{CustomShouldRetryFunc: rest.RetryIfTooManyRequests})
+	resp, err := c.restClient.GET(ctx, path, rest.RequestOptions{})
 	if err != nil {
 		return api.Response{}, fmt.Errorf(errMsgWithId, "get", id, err)
 	}
@@ -94,7 +94,7 @@ func (c *Client) Get(ctx context.Context, id string) (api.Response, error) {
 }
 
 func (c *Client) Create(ctx context.Context, body []byte) (api.Response, error) {
-	resp, err := c.restClient.POST(ctx, endpointPath, bytes.NewReader(body), rest.RequestOptions{CustomShouldRetryFunc: rest.RetryIfTooManyRequests})
+	resp, err := c.restClient.POST(ctx, endpointPath, bytes.NewReader(body), rest.RequestOptions{})
 	if err != nil {
 		return api.Response{}, fmt.Errorf(errMsg, "create", err)
 	}
@@ -123,8 +123,7 @@ func (c *Client) Update(ctx context.Context, id string, body []byte) (api.Respon
 	}
 
 	resp, err := c.restClient.PUT(ctx, path, bytes.NewReader(body), rest.RequestOptions{
-		CustomShouldRetryFunc: rest.RetryIfTooManyRequests,
-		QueryParams:           url.Values{"optimistic-locking-version": []string{version}},
+		QueryParams: url.Values{"optimistic-locking-version": []string{version}},
 	})
 	if err != nil {
 		return api.Response{}, fmt.Errorf(errMsgWithId, "update", id, err)
@@ -154,8 +153,7 @@ func (c *Client) Delete(ctx context.Context, id string) (api.Response, error) {
 	}
 
 	resp, err := c.restClient.DELETE(ctx, path, rest.RequestOptions{
-		CustomShouldRetryFunc: rest.RetryIfTooManyRequests,
-		QueryParams:           url.Values{"optimistic-locking-version": []string{version}},
+		QueryParams: url.Values{"optimistic-locking-version": []string{version}},
 	})
 	if err != nil {
 		return api.Response{}, fmt.Errorf(errMsgWithId, "delete", id, err)


### PR DESCRIPTION
#### **Why** this PR?
- Workflows retried all admin-mode requests unless a 'forbidden' response was received. As the API checks other things first, this led to a large number of retries if, for example, an invalid ID was used.
- Many API clients were customizing retry behavior with the generic `RetryIfTooManyRequests`. Instead, they should honor the per-client retry settings.
- In general, it makes sense to specify where clients _should_ retry, rather than retrying everything with exceptions. 

#### **What** has changed an **how** does it do it?
- The automation client no longer provides a custom retry function for workflow requests with admin access, and its Delete method no longer wraps retry logic around the admin-access options.
- Automation and document delete methods no longer retry everything with the exception of not found.
- All per-request CustomShouldRetryFunc overrides have been removed from the buckets, segments, slo, documents, and settings/permissions clients. These clients now rely on the ShouldRetryFunc configured at the REST client level.
- RetryIfTooManyRequests has been renamed to RetryIfTooManyRequestsOrServiceUnavailable and now also retries on HTTP 503, matching what most callers actually need.

#### How is it **tested**?
- A new test case "GET - Invalid ID does not retry" is added in clients/automation/automation_test.go and verifies that no retries occur for a non-retryable status code.

#### How does it affect **users**?
- Library users should explicitly set client-level retry options, most likely to `RetryIfTooManyRequestsOrServiceUnavailable`.
- `RetryIfTooManyRequests` has been renamed to `RetryIfTooManyRequestsOrServiceUnavailable`.