### PR TITLE
chore: Update to Go v1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-go 1.26.3
+go 1.26.4
 
 module github.com/dynatrace/dynatrace-configuration-as-code-core
 


### PR DESCRIPTION
#### **Why** this PR?
Update to Go v1.26.4

#### **What** has changed and **how** does it do it?
Go version in `go.mod` updated to `1.26.4`

#### How is it **tested**?
CI pipeline

#### How does it affect **users**?
NA
